### PR TITLE
feat(db): add mysql2/promise server connection module (#4)

### DIFF
--- a/docs/local-mysql.md
+++ b/docs/local-mysql.md
@@ -60,6 +60,16 @@ MySQL data is persisted in the named Docker volume declared in `docker-compose.y
 
 That means data survives container restarts and `docker compose down`.
 
+## Application DB module behavior (server-side)
+
+The application uses a dedicated server-side module at `src/lib/server/db.ts`.
+
+- Driver: `mysql2/promise`
+- Access pattern: pooled connections via a shared singleton pool
+- Query safety: pass values as query parameters (`?`) through the `params` argument
+- Runtime guard: module is marked `server-only` and must not be imported by client components
+- Failure behavior: connection failures are mapped to `DatabaseUnavailableError` with guidance to verify local Docker and DB settings
+
 ## Safe local DB reset (project-scoped)
 
 Use this only when you intentionally want a clean local DB.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.577.0",
+        "mysql2": "^3.20.0",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -3964,7 +3965,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4936,6 +4936,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
@@ -5829,6 +5838,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -7121,6 +7139,15 @@
       "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -7986,6 +8013,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8724,6 +8757,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8743,6 +8782,21 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/lucide-react": {
@@ -8960,6 +9014,40 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.20.0.tgz",
+      "integrity": "sha512-eCLUs7BNbgA6nf/MZXsaBO1SfGs0LtLVrJD3WeWq+jPLDWkSufTD+aGMwykfUVPdZnblaUK1a8G/P63cl9FkKg==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -10807,6 +10895,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -11514,7 +11617,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.577.0",
+    "mysql2": "^3.20.0",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1,0 +1,120 @@
+import "server-only";
+
+import mysql, {
+  type Pool,
+  type PoolOptions,
+  type ResultSetHeader,
+  type RowDataPacket,
+} from "mysql2/promise";
+
+const CONNECTION_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "PROTOCOL_CONNECTION_LOST",
+]);
+
+const DEFAULT_DB_PORT = 3306;
+
+type DbParam =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Date
+  | null
+  | Blob
+  | Buffer
+  | Uint8Array
+  | DbParam[]
+  | { [key: string]: DbParam };
+
+type DbParams = DbParam[];
+
+let pool: Pool | undefined;
+
+export class DatabaseUnavailableError extends Error {
+  public constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "DatabaseUnavailableError";
+  }
+}
+
+function resolveConnectionOptions(): PoolOptions {
+  const portValue = process.env.DB_PORT ?? process.env.MYSQL_PORT;
+  const parsedPort = Number.parseInt(portValue ?? String(DEFAULT_DB_PORT), 10);
+
+  return {
+    host: process.env.DB_HOST ?? process.env.MYSQL_HOST ?? "127.0.0.1",
+    port: Number.isNaN(parsedPort) ? DEFAULT_DB_PORT : parsedPort,
+    user: process.env.DB_USER ?? process.env.MYSQL_USER ?? "root",
+    password:
+      process.env.DB_PASSWORD ?? process.env.MYSQL_PASSWORD ?? "localtaskhub",
+    database:
+      process.env.DB_NAME ?? process.env.MYSQL_DATABASE ?? "local-task-hub",
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+    enableKeepAlive: true,
+  };
+}
+
+export function getDbPool(): Pool {
+  if (!pool) {
+    pool = mysql.createPool(resolveConnectionOptions());
+  }
+
+  return pool;
+}
+
+function mapDatabaseError(error: unknown): Error {
+  if (!(error instanceof Error)) {
+    return new Error("Unknown database error");
+  }
+
+  const maybeCode = "code" in error ? error.code : undefined;
+  if (
+    typeof maybeCode === "string" &&
+    CONNECTION_ERROR_CODES.has(maybeCode)
+  ) {
+    return new DatabaseUnavailableError(
+      "Unable to connect to local MySQL. Confirm Docker is running and DB settings are correct.",
+      { cause: error },
+    );
+  }
+
+  return error;
+}
+
+export async function dbQuery<
+  T extends RowDataPacket[] | RowDataPacket[][] | ResultSetHeader,
+>(sql: string, params: DbParams = []): Promise<T> {
+  try {
+    const [result] = await getDbPool().query<T>(sql, params);
+    return result;
+  } catch (error) {
+    throw mapDatabaseError(error);
+  }
+}
+
+export async function dbExecute(
+  sql: string,
+  params: DbParams = [],
+): Promise<ResultSetHeader> {
+  try {
+    const [result] = await getDbPool().execute<ResultSetHeader>(sql, params);
+    return result;
+  } catch (error) {
+    throw mapDatabaseError(error);
+  }
+}
+
+export async function closeDbPool(): Promise<void> {
+  if (!pool) {
+    return;
+  }
+
+  await pool.end();
+  pool = undefined;
+}


### PR DESCRIPTION
## Summary
Implements #4 by adding a dedicated server-side MySQL connection module using `mysql2/promise` with environment-driven local defaults, parameterized query helpers, and documented failure behavior.

## Scope
- Add `src/lib/server/db.ts`:
  - shared MySQL pool creation (`getDbPool`)
  - environment-driven connection settings (`DB_*` with `MYSQL_*` fallbacks)
  - parameterized helpers (`dbQuery`, `dbExecute`)
  - mapped connection failures via `DatabaseUnavailableError`
  - server-only guard (`import "server-only"`)
- Add dependency: `mysql2`
- Update `docs/local-mysql.md` with module behavior and failure guidance

## Files changed
- `src/lib/server/db.ts` (new)
- `package.json`
- `package-lock.json`
- `docs/local-mysql.md`

## Validation performed
- `npm run lint`
- `npm run build`

Both completed successfully.
