### PR TITLE
feat(tasks): implement MySQL-backed task list read path

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { revalidatePath } from "next/cache"
 import { Plus, Search } from "lucide-react"
 
-import { createTask, listTasks } from "@/lib/server/tasks"
+import { createTask, listTasks, type Task, type TaskSourceType } from "@/lib/server/tasks"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -18,6 +18,14 @@ import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 
 const FILTER_CHIPS = ["Status", "Later", "Person", "Tags", "Time", "Source"]
+
+const SOURCE_LABELS: Record<TaskSourceType, string> = {
+  jira: "Jira",
+  gitlab: "GitLab",
+  github: "GitHub",
+  confluence: "Confluence",
+  other: "Other",
+}
 
 async function createTaskAction(formData: FormData) {
   "use server"
@@ -49,6 +57,57 @@ async function createTaskAction(formData: FormData) {
   })
 
   revalidatePath("/")
+}
+
+function truncateNote(note: string, maxLength = 140) {
+  if (note.length <= maxLength) {
+    return note
+  }
+
+  return `${note.slice(0, maxLength).trimEnd()}…`
+}
+
+function formatDuration(totalSeconds: number) {
+  if (totalSeconds <= 0) {
+    return "0m"
+  }
+
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`
+  }
+
+  return `${minutes}m`
+}
+
+function getSourceBadgeLabel(task: Task) {
+  if (!task.firstLink) {
+    return "Local"
+  }
+
+  if (!task.firstLinkSourceType) {
+    return SOURCE_LABELS.other
+  }
+
+  return SOURCE_LABELS[task.firstLinkSourceType]
+}
+
+function getTimeSummary(task: Task) {
+  if (task.timerStartedAt) {
+    return "running now"
+  }
+
+  if (task.todayTrackedSeconds > 0) {
+    return `${formatDuration(task.todayTrackedSeconds)} today`
+  }
+
+  if (task.totalTrackedSeconds > 0) {
+    return `${formatDuration(task.totalTrackedSeconds)} total`
+  }
+
+  return "no time"
 }
 
 export default async function Home() {
@@ -144,35 +203,45 @@ export default async function Home() {
                     <li key={task.id} className="rounded-xl border border-border p-3">
                       <div className="flex items-start justify-between gap-3">
                         <p className="font-medium">{task.title}</p>
-                        <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
-                          {task.status}
-                        </span>
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          <Badge variant="outline" className="text-xs">
+                            {task.status}
+                          </Badge>
+                          <Badge variant="secondary" className="text-xs">
+                            {getSourceBadgeLabel(task)}
+                          </Badge>
+                        </div>
                       </div>
 
-                      <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
-                        {task.later ? <span>later</span> : null}
-                        {task.timerStartedAt ? <span>running now</span> : null}
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {task.later ? (
+                          <Badge variant="outline" className="text-xs">
+                            later
+                          </Badge>
+                        ) : null}
+
+                        {task.tags.map((tag) => (
+                          <Badge key={`${task.id}-tag-${tag}`} variant="outline" className="text-xs">
+                            #{tag}
+                          </Badge>
+                        ))}
+
+                        {task.people.map((person) => (
+                          <Badge
+                            key={`${task.id}-person-${person}`}
+                            variant="outline"
+                            className="text-xs"
+                          >
+                            {person}
+                          </Badge>
+                        ))}
                       </div>
 
                       {task.note ? (
-                        <p className="mt-2 text-sm text-muted-foreground">{task.note}</p>
+                        <p className="mt-2 text-sm text-muted-foreground">{truncateNote(task.note)}</p>
                       ) : null}
 
-                      {task.firstLink ? (
-                        <p className="mt-2 text-xs text-muted-foreground">Link: {task.firstLink}</p>
-                      ) : null}
-
-                      {task.tags.length > 0 ? (
-                        <p className="mt-2 text-xs text-muted-foreground">
-                          Tags: {task.tags.join(", ")}
-                        </p>
-                      ) : null}
-
-                      {task.people.length > 0 ? (
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          People: {task.people.join(", ")}
-                        </p>
-                      ) : null}
+                      <p className="mt-2 text-xs text-muted-foreground">Time: {getTimeSummary(task)}</p>
                     </li>
                   ))}
                 </ul>

--- a/src/lib/server/tasks.ts
+++ b/src/lib/server/tasks.ts
@@ -6,6 +6,8 @@ import { getDbPool } from "@/lib/server/db"
 
 type TaskStatus = "open" | "in_progress" | "blocked" | "waiting" | "review" | "done"
 
+export type TaskSourceType = "jira" | "gitlab" | "github" | "confluence" | "other"
+
 type TaskRow = RowDataPacket & {
   id: number
   title: string
@@ -13,9 +15,12 @@ type TaskRow = RowDataPacket & {
   later: boolean
   note: string | null
   first_link: string | null
+  first_link_source_type: TaskSourceType | null
   tags_serialized: string | null
   people_serialized: string | null
   timer_started_at: Date | null
+  today_tracked_seconds: number | null
+  total_tracked_seconds: number | null
   created_at: Date
   updated_at: Date
 }
@@ -27,9 +32,12 @@ export type Task = {
   later: boolean
   note: string | null
   firstLink: string | null
+  firstLinkSourceType: TaskSourceType | null
   tags: string[]
   people: string[]
   timerStartedAt: Date | null
+  todayTrackedSeconds: number
+  totalTrackedSeconds: number
   createdAt: Date
   updatedAt: Date
 }
@@ -64,6 +72,36 @@ function normalizeList(values?: string[]) {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))]
 }
 
+function inferSourceTypeFromUrl(url: string | null): TaskSourceType {
+  if (!url) {
+    return "other"
+  }
+
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+
+    if (host.includes("atlassian.net") || host.includes("jira")) {
+      return "jira"
+    }
+
+    if (host.includes("gitlab")) {
+      return "gitlab"
+    }
+
+    if (host.includes("github")) {
+      return "github"
+    }
+
+    if (host.includes("confluence")) {
+      return "confluence"
+    }
+  } catch {
+    return "other"
+  }
+
+  return "other"
+}
+
 function mapRow(row: TaskRow): Task {
   return {
     id: row.id,
@@ -72,9 +110,12 @@ function mapRow(row: TaskRow): Task {
     later: row.later,
     note: row.note,
     firstLink: row.first_link,
+    firstLinkSourceType: row.first_link_source_type ?? inferSourceTypeFromUrl(row.first_link),
     tags: parseSerializedList(row.tags_serialized),
     people: parseSerializedList(row.people_serialized),
     timerStartedAt: row.timer_started_at,
+    todayTrackedSeconds: Number(row.today_tracked_seconds ?? 0),
+    totalTrackedSeconds: Number(row.total_tracked_seconds ?? 0),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -97,6 +138,13 @@ export async function listTasks() {
           LIMIT 1
         ) AS first_link,
         (
+          SELECT tl.source_type
+          FROM task_links tl
+          WHERE tl.task_id = t.id
+          ORDER BY tl.created_at ASC, tl.id ASC
+          LIMIT 1
+        ) AS first_link_source_type,
+        (
           SELECT GROUP_CONCAT(tt.tag ORDER BY tt.tag SEPARATOR ?)
           FROM task_tags tt
           WHERE tt.task_id = t.id
@@ -113,6 +161,28 @@ export async function listTasks() {
           ORDER BY ts.started_at DESC, ts.id DESC
           LIMIT 1
         ) AS timer_started_at,
+        (
+          SELECT COALESCE(
+            SUM(
+              CASE
+                WHEN ts.started_at >= CURRENT_DATE()
+                  THEN COALESCE(ts.duration_seconds, TIMESTAMPDIFF(SECOND, ts.started_at, CURRENT_TIMESTAMP(3)))
+                ELSE 0
+              END
+            ),
+            0
+          )
+          FROM task_time_sessions ts
+          WHERE ts.task_id = t.id
+        ) AS today_tracked_seconds,
+        (
+          SELECT COALESCE(
+            SUM(COALESCE(ts.duration_seconds, TIMESTAMPDIFF(SECOND, ts.started_at, CURRENT_TIMESTAMP(3)))),
+            0
+          )
+          FROM task_time_sessions ts
+          WHERE ts.task_id = t.id
+        ) AS total_tracked_seconds,
         t.created_at,
         t.updated_at
       FROM tasks t


### PR DESCRIPTION
## Summary
Implements **issue #6** by wiring the main task list on `/` to the real server-side MySQL read path and rendering Phase 1 list cards.

This PR implements **read/list behavior only**.

Closes #6.

## Scope
- Use server-side task list data from MySQL in the main list area.
- Keep default list ordering by `updated_at DESC`.
- Render Phase 1 list card fields:
  - title
  - status
  - later marker
  - tags
  - person references
  - short note preview
  - time info summary
  - source badge with local fallback behavior
- Preserve existing quick-add/create behavior and existing shell layout from issue #5.
- Show empty state when no tasks exist.

## Out of Scope (intentionally not included)
- Task detail view
- Edit task flow
- Complete/reopen actions
- Search/filter behavior wiring
- Export
- Remote integrations or remote favicon fetching

## Files Changed
- `src/lib/server/tasks.ts`
  - Expanded list query to include source type and time summary fields
  - Kept explicit SQL and server-side data access
  - Added local source inference fallback for unknown/missing source type
- `src/app/page.tsx`
  - Rendered Phase 1 task cards from DB data in list region
  - Added compact note preview and list-friendly time summary display
  - Added local source badge mapping/fallback labels

## Validation Performed
- `npm run lint`
- `npm run build`

Both commands completed successfully.