### PR TITLE
feat: add recently opened tasks area

### DIFF
--- a/.docker/db_schema.sql
+++ b/.docker/db_schema.sql
@@ -109,3 +109,16 @@ CREATE TABLE IF NOT EXISTS task_time_sessions (
 ) ENGINE=InnoDB
   DEFAULT CHARSET=utf8mb4
   COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS task_recent_opens (
+  task_id BIGINT UNSIGNED NOT NULL,
+  last_opened_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (task_id),
+  CONSTRAINT fk_task_recent_opens_task_id
+    FOREIGN KEY (task_id)
+    REFERENCES tasks(id)
+    ON DELETE CASCADE,
+  INDEX idx_task_recent_opens_last_opened_at (last_opened_at)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_unicode_ci;

--- a/e2e/create-task.spec.ts
+++ b/e2e/create-task.spec.ts
@@ -9,14 +9,14 @@ test('create task with title only persists and renders in list', async ({ page }
   await page.getByLabel('Title *').fill(title)
   await page.getByRole('button', { name: 'Create task' }).click()
 
-  const card = page.locator('li', { hasText: title })
+  const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText('open')
   await expect(card).not.toContainText('Running now')
 
   await page.reload()
 
-  const persistedCard = page.locator('li', { hasText: title })
+  const persistedCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(persistedCard).toBeVisible()
   await expect(persistedCard).toContainText('open')
 })
@@ -36,7 +36,7 @@ test('create task with optional fields and tracking persists after reload', asyn
 
   await page.getByRole('button', { name: 'Create task' }).click()
 
-  const card = page.locator('li', { hasText: title })
+  const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText('open')
   await expect(card).toContainText('Running now')
@@ -47,7 +47,7 @@ test('create task with optional fields and tracking persists after reload', asyn
 
   await page.reload()
 
-  const persistedCard = page.locator('li', { hasText: title })
+  const persistedCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(persistedCard).toBeVisible()
   await expect(persistedCard).toContainText('note for issue #2')
   await expect(persistedCard).toContainText('GitHub')
@@ -63,7 +63,7 @@ test('open task detail, edit task, and persist detail changes after reload', asy
   await page.getByLabel('Title *').fill(initialTitle)
   await page.getByRole('button', { name: 'Create task' }).click()
 
-  await page.getByRole('link', { name: initialTitle }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: initialTitle }).click()
 
   await expect(page.getByText('Task detail').first()).toBeVisible()
   await expect(page.locator('#detailTitle')).toHaveValue(initialTitle)
@@ -76,16 +76,16 @@ test('open task detail, edit task, and persist detail changes after reload', asy
 
   await page.getByRole('button', { name: 'Save detail' }).click()
 
-  const updatedCard = page.locator('li', { hasText: updatedTitle })
+  const updatedCard = page.getByTestId('main-task-list').locator('li', { hasText: updatedTitle })
   await expect(updatedCard).toBeVisible()
   await expect(updatedCard).toContainText('blocked')
   await expect(updatedCard).toContainText('Updated detail note')
 
   await page.reload()
-  await page.getByRole('link', { name: updatedTitle }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: updatedTitle }).click()
 
   await expect(page.locator('#detailTitle')).toHaveValue(updatedTitle)
   await expect(page.locator("#detailStatus")).toContainText("blocked")
   await expect(page.locator('#detailNote')).toHaveValue('Updated detail note')
 })
-
+

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -13,7 +13,7 @@ async function submitQuickAdd(page: import('@playwright/test').Page) {
 }
 
 async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
-  const taskCard = page.locator('li', { hasText: title })
+  const taskCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(taskCard).toBeVisible()
 
   const taskLink = taskCard.getByRole('link', { name: title }).first()
@@ -40,11 +40,11 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
   await page.getByLabel('First person references (optional)').fill(`@person-${unique}`)
   await submitQuickAdd(page)
 
-  await expect(page.locator('li', { hasText: openTitle })).toBeVisible()
+  await expect(page.getByTestId('main-task-list').locator('li', { hasText: openTitle })).toBeVisible()
 
   await page.getByLabel('Title *').fill(doneTitle)
   await submitQuickAdd(page)
-  await expect(page.locator('li', { hasText: doneTitle })).toBeVisible()
+  await expect(page.getByTestId('main-task-list').locator('li', { hasText: doneTitle })).toBeVisible()
 
   await openTaskDetail(page, doneTitle)
 
@@ -53,7 +53,7 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
   await markDoneButton.evaluate((element) => {
     ;(element as HTMLButtonElement).click()
   })
-  await expect(page.locator('li', { hasText: doneTitle })).toContainText('done')
+  await expect(page.getByTestId('main-task-list').locator('li', { hasText: doneTitle })).toContainText('done')
 
   await openTaskDetail(page, openTitle)
 

--- a/e2e/recently-opened.spec.ts
+++ b/e2e/recently-opened.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+import mysql from 'mysql2/promise'
+
+async function withDbConnection() {
+  return mysql.createConnection({
+    host: process.env.DB_HOST ?? process.env.MYSQL_HOST ?? '127.0.0.1',
+    port: Number.parseInt(process.env.DB_PORT ?? process.env.MYSQL_PORT ?? '3306', 10),
+    user: process.env.DB_USER ?? process.env.MYSQL_USER ?? 'root',
+    password: process.env.DB_PASSWORD ?? process.env.MYSQL_PASSWORD ?? 'localtaskhub',
+    database: process.env.DB_NAME ?? process.env.MYSQL_DATABASE ?? 'local-task-hub'
+  })
+}
+
+test('recently opened area tracks recency, deduplicates, bounds to five, and persists across reload', async ({ page }) => {
+  test.setTimeout(120000)
+  const unique = Date.now().toString()
+  const titles = Array.from({ length: 6 }, (_, index) => 'Issue36 Recent ' + unique + ' ' + String(index + 1))
+
+  const connection = await withDbConnection()
+  const taskIds: number[] = []
+
+  try {
+    for (const title of titles) {
+      const [insertResult] = await connection.execute<mysql.ResultSetHeader>(
+        'INSERT INTO tasks (title) VALUES (?)',
+        [title]
+      )
+      taskIds.push(insertResult.insertId)
+    }
+  } finally {
+    await connection.end()
+  }
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+  const recentArea = page.locator("[aria-label='Recently opened tasks']")
+  await expect(recentArea).toBeVisible()
+
+  for (let index = 0; index < taskIds.length; index += 1) {
+    await page.goto('/?taskId=' + String(taskIds[index]) + '#task-detail', { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('#detailTitle')).toHaveValue(titles[index])
+    await page.waitForTimeout(20)
+  }
+
+  const recentItems = recentArea.locator('li')
+  await expect(recentItems).toHaveCount(5)
+  await expect(recentItems.nth(0)).toContainText(titles[5])
+  await expect(recentArea.getByRole('link', { name: titles[4] })).toHaveCount(1)
+  await expect(recentArea.getByRole('link', { name: titles[3] })).toHaveCount(1)
+  await expect(recentArea.getByRole('link', { name: titles[2] })).toHaveCount(1)
+  await expect(recentArea.getByRole('link', { name: titles[1] })).toHaveCount(1)
+  await expect(recentArea.getByRole('link', { name: titles[0] })).toHaveCount(0)
+
+  await page.goto('/?taskId=' + String(taskIds[2]) + '#task-detail', { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('#detailTitle')).toHaveValue(titles[2])
+
+  await expect(recentItems).toHaveCount(5)
+  await expect(recentItems.nth(0)).toContainText(titles[2])
+  await expect(recentArea.getByRole('link', { name: titles[2] })).toHaveCount(1)
+
+  await page.reload()
+
+  await expect(recentArea).toBeVisible()
+  await expect(recentItems).toHaveCount(5)
+  await expect(recentItems.nth(0)).toContainText(titles[2])
+  await expect(recentArea.getByRole('link', { name: titles[2] })).toHaveCount(1)
+})

--- a/e2e/task-complete-reopen.spec.ts
+++ b/e2e/task-complete-reopen.spec.ts
@@ -9,11 +9,11 @@ test("mark task done and reopen persists status while preserving later flag", as
   await page.getByLabel("Title *").fill(title)
   await page.getByRole("button", { name: "Create task" }).click()
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText("open")
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   await page.locator("#detailLater").focus()
   await page.keyboard.press("Space")
@@ -32,7 +32,7 @@ test("mark task done and reopen persists status while preserving later flag", as
   await expect(page.getByRole("button", { name: "Reopen task" })).toBeVisible()
 
   await page.reload()
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   await expect(card).toContainText("done")
   await expect(card).toContainText("later")
@@ -47,13 +47,13 @@ test("mark task done and reopen persists status while preserving later flag", as
   await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
 
   await page.reload()
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
-  const persistedCard = page.locator("li", { hasText: title })
+  const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toBeVisible()
   await expect(persistedCard).toContainText("open")
   await expect(persistedCard).toContainText("later")
   await expect(page.locator("#detailStatus")).toContainText("open")
   await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
 })
-
+

--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -11,7 +11,7 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await quickAdd.getByLabel('Title *').fill(title)
   await quickAdd.getByLabel('Title *').press('Enter')
 
-  await page.getByRole('link', { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
 
   await expect(page.getByText('Task detail').first()).toBeVisible()
   await expect(page.getByLabel('Attached links')).toHaveCount(0)
@@ -46,7 +46,7 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await popup.close()
 
   await page.reload()
-  await page.getByRole('link', { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
 
   await expect(page.locator('#detailLinks')).toHaveValue(
     'https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab',
@@ -63,14 +63,14 @@ test('task detail supports structured time session editing and explicit removal'
   await page.getByLabel('Title *').fill(title)
   await page.getByRole('button', { name: 'Create task' }).click()
 
-  const card = page.locator('li', { hasText: title })
+  const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
 
   await card.getByRole('button', { name: 'Start tracking' }).click()
   await page.waitForTimeout(1100)
   await card.getByRole('button', { name: 'Stop tracking' }).click()
 
-  await page.getByRole('link', { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
 
@@ -86,7 +86,7 @@ test('task detail supports structured time session editing and explicit removal'
   })
 
   await page.reload()
-  await page.getByRole('link', { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
 
   await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(startedAt)
   await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(endedAt)
@@ -99,7 +99,7 @@ test('task detail supports structured time session editing and explicit removal'
   })
 
   await page.reload()
-  await page.getByRole('link', { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(0)
   await expect(page.getByText('No time sessions yet.')).toBeVisible()

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -29,7 +29,7 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText("Stopped")
   await expect(card).toContainText("Today: 0m")
@@ -43,7 +43,7 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   await card.getByRole("button", { name: "Stop tracking" }).click()
   await expect(card).toContainText("Stopped")
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -60,11 +60,11 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
 
   await page.reload()
 
-  const persistedCard = page.locator("li", { hasText: title })
+  const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toContainText("Stopped")
   await expect(persistedCard).toContainText("Total: 2m")
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
   await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(correctedEndedAt.toISOString())
 
@@ -80,14 +80,14 @@ test("double start submission does not create duplicate running sessions", async
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
   await card.getByRole("button", { name: "Start tracking" }).dblclick()
 
   await expect(card.getByRole("button", { name: "Stop tracking" })).toBeVisible({ timeout: 10000 })
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -104,7 +104,7 @@ test("double stop submission does not mutate ended session twice", async ({ page
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
   await card.getByRole("button", { name: "Start tracking" }).click()
@@ -115,7 +115,7 @@ test("double stop submission does not mutate ended session twice", async ({ page
   await card.getByRole("button", { name: "Stop tracking" }).dblclick()
   await expect(card).toContainText("Stopped")
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -151,7 +151,7 @@ test("today totals include overlap for sessions that started before midnight", a
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
   await card.getByRole("button", { name: "Start tracking" }).click()
@@ -159,7 +159,7 @@ test("today totals include overlap for sessions that started before midnight", a
   await page.waitForTimeout(1100)
   await card.getByRole("button", { name: "Stop tracking" }).click()
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
   await page.locator("#detailTimeSessionStartedAt-0").fill(startedAt.toISOString())
@@ -181,7 +181,7 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
-  const card = page.locator("li", { hasText: title })
+  const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
 
   await card.getByRole("button", { name: "Start tracking" }).click()
   await expect(card.getByRole("button", { name: "Stop tracking" })).toBeVisible({ timeout: 10000 })
@@ -189,7 +189,7 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   await page.waitForTimeout(1200)
   await card.getByRole("button", { name: "Stop tracking" }).click()
 
-  await page.getByRole("link", { name: title }).click()
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
 
   const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
   const startedAt = new Date(startedAtRaw)
@@ -202,6 +202,6 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   await expect(card).toContainText("Total: 10m")
 
   await page.reload()
-  const persistedCard = page.locator("li", { hasText: title })
+  const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toContainText("Total: 10m")
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -673,7 +673,7 @@ export default async function Home({
                   </EmptyContent>
                 </Empty>
               ) : (
-                <ul className='space-y-3'>
+                <ul className='space-y-3' aria-label='Main task list' data-testid='main-task-list'>
                   {tasks.map((task) => {
                     const isSelected = selectedTask?.id === task.id;
                     const taskHrefParams = new URLSearchParams(taskLinkParams.toString());
@@ -738,8 +738,8 @@ export default async function Home({
 
                         <div className='mt-2 space-y-2'>
                           <p className='text-xs text-muted-foreground'>
-                            {task.timerStartedAt ? 'Running now' : 'Stopped'} · Today:{' '}
-                            {getTaskTodayLabel(task)} · Total: {getTaskTotalLabel(task)}
+                            {task.timerStartedAt ? 'Running now' : 'Stopped'} � Today:{' '}
+                            {getTaskTodayLabel(task)} � Total: {getTaskTotalLabel(task)}
                           </p>
                           <form
                             action={task.timerStartedAt ? stopTrackingAction : startTrackingAction}
@@ -1125,4 +1125,5 @@ export default async function Home({
     </div>
   );
 }
+
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,11 @@ import { Download, Play, Plus, Search, Square } from 'lucide-react';
 import {
   createTask,
   getTaskDetail,
+  listRecentlyOpenedTasks,
   listTasks,
+  recordTaskOpened,
   updateTaskDetail,
   type Task,
-  type TaskDetail,
   type TaskListFilters,
   type TaskSourceType,
   type TaskTimeRelationFilter
@@ -237,7 +238,7 @@ function truncateNote(note: string, maxLength = 140) {
     return note;
   }
 
-  return `${note.slice(0, maxLength).trimEnd()}…`;
+  return `${note.slice(0, maxLength).trimEnd()}...`;
 }
 
 function formatDuration(totalSeconds: number) {
@@ -295,7 +296,7 @@ function truncateLinkLabel(url: string, maxLength = 96) {
     return url;
   }
 
-  return `${url.slice(0, maxLength).trimEnd()}…`;
+  return `${url.slice(0, maxLength).trimEnd()}...`;
 }
 
 export default async function Home({
@@ -345,6 +346,12 @@ export default async function Home({
   const tasks = await listTasks(filters);
   const selectedTask =
     Number.isNaN(selectedTaskId) ? null : await getTaskDetail(selectedTaskId);
+
+  if (selectedTask) {
+    await recordTaskOpened(selectedTask.id);
+  }
+
+  const recentlyOpenedTasks = await listRecentlyOpenedTasks();
   const todayTotalTrackedSeconds = await getTodayTotalTrackedSeconds();
 
   const peopleOptions = [...new Set(allTasks.flatMap((task) => task.people))].sort((a, b) =>
@@ -590,6 +597,49 @@ export default async function Home({
                   </div>
                 ) : null}
               </fieldset>
+            </CardContent>
+          </Card>
+
+          <Card aria-label='Recently opened tasks'>
+            <CardHeader className='border-b border-border'>
+              <CardTitle className='text-base tracking-tight'>Recently opened</CardTitle>
+              <CardDescription>Latest task detail views (up to 5).</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {recentlyOpenedTasks.length === 0 ? (
+                <p className='text-sm text-muted-foreground'>No recently opened tasks yet.</p>
+              ) : (
+                <ul className='space-y-2'>
+                  {recentlyOpenedTasks.map((task) => {
+                    const taskHrefParams = new URLSearchParams(taskLinkParams.toString());
+                    taskHrefParams.set('taskId', String(task.id));
+
+                    return (
+                      <li
+                        key={`recent-${task.id}`}
+                        className='flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2'
+                      >
+                        <Link
+                          href={`/?${taskHrefParams.toString()}#task-detail`}
+                          className='truncate text-sm underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                        >
+                          {task.title}
+                        </Link>
+                        <div className='flex shrink-0 items-center gap-2'>
+                          {task.later ? (
+                            <Badge variant='outline' className='text-[10px]'>
+                              later
+                            </Badge>
+                          ) : null}
+                          <Badge variant='outline' className='text-[10px]'>
+                            {task.status}
+                          </Badge>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
             </CardContent>
           </Card>
 
@@ -1075,3 +1125,4 @@ export default async function Home({
     </div>
   );
 }
+

--- a/src/lib/server/tasks.ts
+++ b/src/lib/server/tasks.ts
@@ -10,6 +10,10 @@ const TASK_STATUSES = ["open", "in_progress", "blocked", "waiting", "review", "d
 
 type TaskStatus = (typeof TASK_STATUSES)[number]
 
+const MAX_RECENTLY_OPENED_TASKS = 5
+
+let hasEnsuredTaskRecentOpensTable = false
+
 export type TaskSourceType = "jira" | "gitlab" | "github" | "confluence" | "other"
 
 export type TaskTimeRelationFilter = "today" | "this_week" | "no_time" | "recently_updated"
@@ -73,6 +77,14 @@ type TaskTimeSessionRow = RowDataPacket & {
   duration_seconds: number | null
 }
 
+type RecentlyOpenedTaskRow = RowDataPacket & {
+  id: number
+  title: string
+  status: TaskStatus
+  later: boolean
+  last_opened_at: Date
+}
+
 export type Task = {
   id: number
   title: string
@@ -109,6 +121,14 @@ export type TaskDetail = {
   timeSessions: TaskTimeSession[]
   createdAt: Date
   updatedAt: Date
+}
+
+export type RecentlyOpenedTask = {
+  id: number
+  title: string
+  status: TaskStatus
+  later: boolean
+  openedAt: Date
 }
 
 export type CreateTaskInput = {
@@ -206,6 +226,78 @@ function mapRow(row: TaskRow): Task {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
+}
+
+async function ensureTaskRecentOpensTable() {
+  if (hasEnsuredTaskRecentOpensTable) {
+    return
+  }
+
+  await getDbPool().execute(`
+    CREATE TABLE IF NOT EXISTS task_recent_opens (
+      task_id BIGINT UNSIGNED NOT NULL,
+      last_opened_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+      PRIMARY KEY (task_id),
+      CONSTRAINT fk_task_recent_opens_task_id
+        FOREIGN KEY (task_id)
+        REFERENCES tasks(id)
+        ON DELETE CASCADE,
+      INDEX idx_task_recent_opens_last_opened_at (last_opened_at)
+    ) ENGINE=InnoDB
+      DEFAULT CHARSET=utf8mb4
+      COLLATE=utf8mb4_unicode_ci
+  `)
+
+  hasEnsuredTaskRecentOpensTable = true
+}
+
+export async function recordTaskOpened(taskId: number) {
+  await ensureTaskRecentOpensTable()
+
+  await getDbPool().execute(
+    `
+      INSERT INTO task_recent_opens (
+        task_id,
+        last_opened_at
+      ) VALUES (?, CURRENT_TIMESTAMP(3))
+      ON DUPLICATE KEY UPDATE
+        last_opened_at = VALUES(last_opened_at)
+    `,
+    [taskId],
+  )
+}
+
+export async function listRecentlyOpenedTasks(limit = MAX_RECENTLY_OPENED_TASKS) {
+  await ensureTaskRecentOpensTable()
+
+  const boundedLimit = Number.isFinite(limit)
+    ? Math.min(Math.max(Math.floor(limit), 1), 20)
+    : MAX_RECENTLY_OPENED_TASKS
+
+  const [rows] = await getDbPool().query<RecentlyOpenedTaskRow[]>(
+    `
+      SELECT
+        t.id,
+        t.title,
+        t.status,
+        t.later,
+        tro.last_opened_at
+      FROM task_recent_opens tro
+      INNER JOIN tasks t
+        ON t.id = tro.task_id
+      ORDER BY tro.last_opened_at DESC, tro.task_id DESC
+      LIMIT ?
+    `,
+    [boundedLimit],
+  )
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    later: row.later,
+    openedAt: row.last_opened_at,
+  })) satisfies RecentlyOpenedTask[]
 }
 
 export async function listTasks(filters: TaskListFilters = {}) {
@@ -740,3 +832,4 @@ export async function updateTaskDetail(input: UpdateTaskDetailInput) {
     connection.release()
   }
 }
+


### PR DESCRIPTION
## Summary
- add a compact Recently opened area to the main UI
- track task open/view recency and refresh order on reopen
- persist recently opened state in MySQL and show latest 5
- keep existing main task list sorting/filtering behavior unchanged
- add Playwright coverage for recency ordering, dedupe, bounds, and reload persistence

## Files changed
- src/app/page.tsx
- src/lib/server/tasks.ts
- .docker/db_schema.sql
- e2e/recently-opened.spec.ts

## Validation
- npm run lint
- npx playwright test e2e/recently-opened.spec.ts --project=chromium

Closes #36