### PR TITLE
Improve Quick Add and Task Detail layout usability

### DIFF
--- a/e2e/create-task.spec.ts
+++ b/e2e/create-task.spec.ts
@@ -1,20 +1,41 @@
 import { expect, test } from '@playwright/test'
 
+async function openQuickAdd(page: import('@playwright/test').Page) {
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
+    page.getByRole('link', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
+}
+
+async function submitQuickAdd(page: import('@playwright/test').Page) {
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.getByRole('button', { name: 'Create task' }).click(),
+  ])
+}
+
+async function showOnlyTask(page: import('@playwright/test').Page, title: string) {
+  await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: 'domcontentloaded' })
+}
+
 test('create task with title only persists and renders in list', async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue2 Title Only ${unique}`
 
   await page.goto('http://localhost:3000/')
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(title)
-  await page.getByRole('button', { name: 'Create task' }).click()
+  await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText('open')
   await expect(card).not.toContainText('Running now')
 
-  await page.reload()
+  await showOnlyTask(page, title)
 
   const persistedCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(persistedCard).toBeVisible()
@@ -27,6 +48,7 @@ test('create task with optional fields and tracking persists after reload', asyn
 
   await page.goto('http://localhost:3000/')
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(title)
   await page.getByLabel('Note (optional)').fill('note for issue #2')
   await page.getByLabel('First link (optional)').fill('https://github.com/vercel/next.js')
@@ -34,8 +56,9 @@ test('create task with optional fields and tracking persists after reload', asyn
   await page.getByLabel('First person references (optional)').fill('@anna, @max')
   await page.getByText('Start time tracking now').click()
 
-  await page.getByRole('button', { name: 'Create task' }).click()
+  await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText('open')
@@ -45,7 +68,7 @@ test('create task with optional fields and tracking persists after reload', asyn
   await expect(card).toContainText('@anna')
   await expect(card).toContainText('@max')
 
-  await page.reload()
+  await showOnlyTask(page, title)
 
   const persistedCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(persistedCard).toBeVisible()
@@ -60,12 +83,17 @@ test('open task detail, edit task, and persist detail changes after reload', asy
 
   await page.goto('/')
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(initialTitle)
-  await page.getByRole('button', { name: 'Create task' }).click()
+  await submitQuickAdd(page)
 
-  await page.getByTestId('main-task-list').getByRole('link', { name: initialTitle }).click()
+  await showOnlyTask(page, initialTitle)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: initialTitle }).click(),
+  ])
 
-  await expect(page.getByText('Task detail').first()).toBeVisible()
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
   await expect(page.locator('#detailTitle')).toHaveValue(initialTitle)
 
   await page.locator('#detailTitle').fill(updatedTitle)
@@ -74,18 +102,57 @@ test('open task detail, edit task, and persist detail changes after reload', asy
   await page.getByRole("option", { name: "blocked" }).click()
   await page.locator('#detailNote').fill('Updated detail note')
 
-  await page.getByRole('button', { name: 'Save detail' }).click()
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.getByRole('button', { name: 'Save detail' }).click(),
+  ])
+
+  await expect(page.locator('#detailTitle')).toHaveValue(updatedTitle)
+  await page.getByRole('link', { name: 'Close' }).click()
+  await showOnlyTask(page, updatedTitle)
 
   const updatedCard = page.getByTestId('main-task-list').locator('li', { hasText: updatedTitle })
   await expect(updatedCard).toBeVisible()
   await expect(updatedCard).toContainText('blocked')
   await expect(updatedCard).toContainText('Updated detail note')
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole('link', { name: updatedTitle }).click()
+  await showOnlyTask(page, updatedTitle)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: updatedTitle }).click(),
+  ])
 
   await expect(page.locator('#detailTitle')).toHaveValue(updatedTitle)
   await expect(page.locator("#detailStatus")).toContainText("blocked")
   await expect(page.locator('#detailNote')).toHaveValue('Updated detail note')
+})
+
+test('closing task detail dialog removes taskId from the URL', async ({ page }) => {
+  const unique = Date.now().toString()
+  const title = `Issue50 Close Detail ${unique}`
+
+  await page.goto('/')
+
+  await openQuickAdd(page)
+  await page.getByLabel('Title *').fill(title)
+  await submitQuickAdd(page)
+
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
+  await expect(page).toHaveURL(/taskId=/)
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
+
+  await Promise.all([
+    page.waitForURL((url) => !url.searchParams.has('taskId'), {
+      waitUntil: 'domcontentloaded',
+    }),
+    page.getByRole('button', { name: 'Close' }).click(),
+  ])
+
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toHaveCount(0)
+  await expect(page).not.toHaveURL(/taskId=/)
 })
 

--- a/e2e/create-task.spec.ts
+++ b/e2e/create-task.spec.ts
@@ -1,11 +1,10 @@
 import { expect, test } from '@playwright/test'
 
 async function openQuickAdd(page: import('@playwright/test').Page) {
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
-    page.getByRole('link', { name: 'Create task' }).click(),
-  ])
-  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
+  await page.getByRole('link', { name: 'Create task' }).click()
+  const quickAdd = page.getByRole('dialog', { name: 'Quick add' })
+  await expect(quickAdd).toBeVisible()
+  await expect(quickAdd.getByLabel('Title *')).toBeEditable()
 }
 
 async function submitQuickAdd(page: import('@playwright/test').Page) {
@@ -13,10 +12,17 @@ async function submitQuickAdd(page: import('@playwright/test').Page) {
     page.waitForResponse((response) => response.request().method() === 'POST'),
     page.getByRole('button', { name: 'Create task' }).click(),
   ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
 }
 
 async function showOnlyTask(page: import('@playwright/test').Page, title: string) {
   await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: 'domcontentloaded' })
+}
+
+async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
+  await expect(page.locator('#detailTitle')).toHaveValue(title)
 }
 
 test('create task with title only persists and renders in list', async ({ page }) => {
@@ -24,6 +30,7 @@ test('create task with title only persists and renders in list', async ({ page }
   const title = `Issue2 Title Only ${unique}`
 
   await page.goto('http://localhost:3000/')
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(title)
@@ -47,6 +54,7 @@ test('create task with optional fields and tracking persists after reload', asyn
   const title = `Issue2 Populated ${unique}`
 
   await page.goto('http://localhost:3000/')
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(title)
@@ -82,19 +90,14 @@ test('open task detail, edit task, and persist detail changes after reload', asy
   const updatedTitle = `${initialTitle} Updated`
 
   await page.goto('/')
+  await showOnlyTask(page, initialTitle)
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(initialTitle)
   await submitQuickAdd(page)
 
   await showOnlyTask(page, initialTitle)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: initialTitle }).click(),
-  ])
-
-  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
-  await expect(page.locator('#detailTitle')).toHaveValue(initialTitle)
+  await openTaskDetail(page, initialTitle)
 
   await page.locator('#detailTitle').fill(updatedTitle)
   const statusTrigger = page.locator("#detailStatus")
@@ -117,10 +120,7 @@ test('open task detail, edit task, and persist detail changes after reload', asy
   await expect(updatedCard).toContainText('Updated detail note')
 
   await showOnlyTask(page, updatedTitle)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: updatedTitle }).click(),
-  ])
+  await openTaskDetail(page, updatedTitle)
 
   await expect(page.locator('#detailTitle')).toHaveValue(updatedTitle)
   await expect(page.locator("#detailStatus")).toContainText("blocked")
@@ -132,16 +132,14 @@ test('closing task detail dialog removes taskId from the URL', async ({ page }) 
   const title = `Issue50 Close Detail ${unique}`
 
   await page.goto('/')
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(title)
   await submitQuickAdd(page)
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
   await expect(page).toHaveURL(/taskId=/)
   await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
 

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -7,9 +7,18 @@ function uniqueToken() {
 async function submitQuickAdd(page: import('@playwright/test').Page) {
   const createButton = page.getByRole('button', { name: 'Create task' })
   await expect(createButton).toBeVisible()
-  await createButton.evaluate((element) => {
-    ;(element as HTMLButtonElement).click()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    createButton.click(),
+  ])
+}
+
+async function openQuickAdd(page: import('@playwright/test').Page) {
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
+    page.getByRole('link', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
 }
 
 async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
@@ -33,6 +42,7 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
 
   await page.goto('/')
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(openTitle)
   await page.getByLabel('Note (optional)').fill(`Note ${unique}`)
   await page.getByLabel('First link (optional)').fill(`https://github.com/vercel/next.js/issues/${unique}`)
@@ -42,6 +52,7 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
 
   await expect(page.getByTestId('main-task-list').locator('li', { hasText: openTitle })).toBeVisible()
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(doneTitle)
   await submitQuickAdd(page)
   await expect(page.getByTestId('main-task-list').locator('li', { hasText: doneTitle })).toBeVisible()

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -11,17 +11,22 @@ async function submitQuickAdd(page: import('@playwright/test').Page) {
     page.waitForResponse((response) => response.request().method() === 'POST'),
     createButton.click(),
   ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
 }
 
 async function openQuickAdd(page: import('@playwright/test').Page) {
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
-    page.getByRole('link', { name: 'Create task' }).click(),
-  ])
-  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
+  await page.getByRole('link', { name: 'Create task' }).click()
+  const quickAdd = page.getByRole('dialog', { name: 'Quick add' })
+  await expect(quickAdd).toBeVisible()
+  await expect(quickAdd.getByLabel('Title *')).toBeEditable()
+}
+
+async function showOnlyTask(page: import('@playwright/test').Page, title: string) {
+  await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: 'domcontentloaded' })
 }
 
 async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
+  await showOnlyTask(page, title)
   const taskCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(taskCard).toBeVisible()
 
@@ -31,7 +36,7 @@ async function openTaskDetail(page: import('@playwright/test').Page, title: stri
   expect(taskHref).toBeTruthy()
   expect(taskHref).toContain('taskId=')
 
-  await page.goto(taskHref!)
+  await page.goto(taskHref!, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('#detailTitle')).toHaveValue(title)
 }
 
@@ -41,6 +46,7 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
   const doneTitle = `Issue12 Done ${unique}`
 
   await page.goto('/')
+  await showOnlyTask(page, unique)
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(openTitle)
@@ -50,20 +56,22 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
   await page.getByLabel('First person references (optional)').fill(`@person-${unique}`)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, openTitle)
   await expect(page.getByTestId('main-task-list').locator('li', { hasText: openTitle })).toBeVisible()
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(doneTitle)
   await submitQuickAdd(page)
+  await showOnlyTask(page, doneTitle)
   await expect(page.getByTestId('main-task-list').locator('li', { hasText: doneTitle })).toBeVisible()
 
   await openTaskDetail(page, doneTitle)
 
   const markDoneButton = page.getByRole('button', { name: 'Mark done' })
   await expect(markDoneButton).toBeVisible()
-  await markDoneButton.evaluate((element) => {
-    ;(element as HTMLButtonElement).click()
-  })
+  await markDoneButton.click()
+  await expect(page.getByRole('button', { name: 'Reopen task' })).toBeVisible()
+  await showOnlyTask(page, doneTitle)
   await expect(page.getByTestId('main-task-list').locator('li', { hasText: doneTitle })).toContainText('done')
 
   await openTaskDetail(page, openTitle)
@@ -87,7 +95,8 @@ test('exports selected task as markdown and open tasks as JSON', async ({ page }
   expect(markdownContent).toContain(`@person-${unique}`)
   expect(markdownContent).toContain('## Time summary')
 
-  await page.goto('/')
+  await page.getByRole('button', { name: 'Close' }).click()
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toHaveCount(0)
 
   const openExportLink = page.getByRole('link', { name: 'Export open JSON' })
   await expect(openExportLink).toBeVisible()

--- a/e2e/recently-opened.spec.ts
+++ b/e2e/recently-opened.spec.ts
@@ -11,35 +11,42 @@ async function withDbConnection() {
   })
 }
 
+async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  const detailDialog = page.getByRole('dialog', { name: 'Task detail' })
+  await expect(detailDialog).toBeVisible()
+  await expect(page.locator('#detailTitle')).toHaveValue(title)
+}
+
+async function closeTaskDetail(page: import('@playwright/test').Page) {
+  const detailDialog = page.getByRole('dialog', { name: 'Task detail' })
+  await detailDialog.getByRole('button', { name: 'Close' }).click()
+  await expect(detailDialog).toHaveCount(0)
+}
+
 test('recently opened area tracks recency, deduplicates, bounds to five, and persists across reload', async ({ page }) => {
   test.setTimeout(120000)
   const unique = Date.now().toString()
   const titles = Array.from({ length: 6 }, (_, index) => 'Issue36 Recent ' + unique + ' ' + String(index + 1))
 
   const connection = await withDbConnection()
-  const taskIds: number[] = []
 
   try {
     for (const title of titles) {
-      const [insertResult] = await connection.execute<mysql.ResultSetHeader>(
-        'INSERT INTO tasks (title) VALUES (?)',
-        [title]
-      )
-      taskIds.push(insertResult.insertId)
+      await connection.execute<mysql.ResultSetHeader>('INSERT INTO tasks (title) VALUES (?)', [title])
     }
   } finally {
     await connection.end()
   }
 
-  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.goto(`/?q=${encodeURIComponent(unique)}`, { waitUntil: 'domcontentloaded' })
 
   const recentArea = page.locator("[aria-label='Recently opened tasks']")
   await expect(recentArea).toBeVisible()
 
-  for (let index = 0; index < taskIds.length; index += 1) {
-    await page.goto('/?taskId=' + String(taskIds[index]) + '#task-detail', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('#detailTitle')).toHaveValue(titles[index])
-    await page.waitForTimeout(20)
+  for (const title of titles) {
+    await openTaskDetail(page, title)
+    await closeTaskDetail(page)
   }
 
   const recentItems = recentArea.locator('li')
@@ -51,14 +58,14 @@ test('recently opened area tracks recency, deduplicates, bounds to five, and per
   await expect(recentArea.getByRole('link', { name: titles[1] })).toHaveCount(1)
   await expect(recentArea.getByRole('link', { name: titles[0] })).toHaveCount(0)
 
-  await page.goto('/?taskId=' + String(taskIds[2]) + '#task-detail', { waitUntil: 'domcontentloaded' })
-  await expect(page.locator('#detailTitle')).toHaveValue(titles[2])
+  await openTaskDetail(page, titles[2])
+  await closeTaskDetail(page)
 
   await expect(recentItems).toHaveCount(5)
   await expect(recentItems.nth(0)).toContainText(titles[2])
   await expect(recentArea.getByRole('link', { name: titles[2] })).toHaveCount(1)
 
-  await page.reload()
+  await page.reload({ waitUntil: 'domcontentloaded' })
 
   await expect(recentArea).toBeVisible()
   await expect(recentItems).toHaveCount(5)

--- a/e2e/search-filtering.spec.ts
+++ b/e2e/search-filtering.spec.ts
@@ -18,14 +18,14 @@ async function submitQuickAdd(page: import('@playwright/test').Page) {
     page.waitForResponse((response) => response.request().method() === 'POST'),
     createButton.click(),
   ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
 }
 
 async function openQuickAdd(page: import('@playwright/test').Page) {
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
-    page.getByRole('link', { name: 'Create task' }).click(),
-  ])
-  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
+  await page.getByRole('link', { name: 'Create task' }).click()
+  const quickAdd = page.getByRole('dialog', { name: 'Quick add' })
+  await expect(quickAdd).toBeVisible()
+  await expect(quickAdd.getByLabel('Title *')).toBeEditable()
 }
 
 test('live search and combinable filters work with persisted data', async ({ page }) => {
@@ -39,6 +39,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
   const urlToken = `issue11-${unique}`
 
   await page.goto('/')
+  await page.goto(`/?q=${encodeURIComponent(unique)}`, { waitUntil: 'domcontentloaded' })
 
   await openQuickAdd(page)
   await page.getByLabel('Title *').fill(targetTitle)
@@ -87,7 +88,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
     await connection.end()
   }
 
-  await page.reload()
+  await page.reload({ waitUntil: 'domcontentloaded' })
 
   await expect(targetCard).toBeVisible()
 
@@ -109,7 +110,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
   await expect(page.locator('li', { hasText: targetTitle })).toBeVisible()
   await expect(page.locator('li', { hasText: otherTitle })).toHaveCount(0)
 
-  await page.goto('/')
+  await page.goto(`/?q=${encodeURIComponent(unique)}`, { waitUntil: 'domcontentloaded' })
   await page.locator("#status").click()
   await page.getByRole("option", { name: "blocked" }).click()
   await page.locator("#later").click()
@@ -130,7 +131,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
   await expect(page.locator('li', { hasText: targetTitle })).toBeVisible()
   await expect(page.locator('li', { hasText: otherTitle })).toHaveCount(0)
 
-  await page.reload()
+  await page.reload({ waitUntil: 'domcontentloaded' })
 
   await expect(page.locator('li', { hasText: targetTitle })).toBeVisible()
   await expect(page.locator('li', { hasText: otherTitle })).toHaveCount(0)

--- a/e2e/search-filtering.spec.ts
+++ b/e2e/search-filtering.spec.ts
@@ -14,9 +14,18 @@ async function withDbConnection() {
 async function submitQuickAdd(page: import('@playwright/test').Page) {
   const createButton = page.getByRole('button', { name: 'Create task' })
   await expect(createButton).toBeVisible()
-  await createButton.evaluate((element) => {
-    ;(element as HTMLButtonElement).click()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    createButton.click(),
+  ])
+}
+
+async function openQuickAdd(page: import('@playwright/test').Page) {
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
+    page.getByRole('link', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
 }
 
 test('live search and combinable filters work with persisted data', async ({ page }) => {
@@ -31,6 +40,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
 
   await page.goto('/')
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(targetTitle)
   await page.getByLabel('Note (optional)').fill(`Contains ${noteToken}`)
   await page
@@ -43,6 +53,7 @@ test('live search and combinable filters work with persisted data', async ({ pag
   const targetCard = page.locator('li', { hasText: targetTitle })
   await expect(targetCard).toBeVisible()
 
+  await openQuickAdd(page)
   await page.getByLabel('Title *').fill(otherTitle)
   await page.getByLabel('Note (optional)').fill(`other-${unique}`)
   await page.getByLabel('First link (optional)').fill(`https://example.com/${unique}`)
@@ -124,4 +135,4 @@ test('live search and combinable filters work with persisted data', async ({ pag
   await expect(page.locator('li', { hasText: targetTitle })).toBeVisible()
   await expect(page.locator('li', { hasText: otherTitle })).toHaveCount(0)
 })
-
+

--- a/e2e/task-complete-reopen.spec.ts
+++ b/e2e/task-complete-reopen.spec.ts
@@ -1,46 +1,74 @@
 import { expect, test } from "@playwright/test"
 
+async function showOnlyTask(page: import("@playwright/test").Page, title: string) {
+  await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: "domcontentloaded" })
+}
+
+async function openTaskDetail(page: import("@playwright/test").Page, title: string) {
+  if ((await page.locator("#task-detail").count()) > 0) {
+    await expect(page.locator("#detailTitle")).toHaveValue(title)
+    return
+  }
+
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await expect(page.getByRole("dialog", { name: "Task detail" })).toBeVisible()
+  await expect(page.locator("#detailTitle")).toHaveValue(title)
+}
+
+async function closeTaskDetail(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: "Close" }).click()
+  await expect(page.getByRole("dialog", { name: "Task detail" })).toHaveCount(0)
+}
+
 test("mark task done and reopen persists status while preserving later flag", async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue9 Complete Reopen ${unique}`
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: "domcontentloaded" }),
-    page.getByRole("link", { name: "Create task" }).click(),
-  ])
+  await page.getByRole("link", { name: "Create task" }).click()
   await expect(page.getByRole("dialog", { name: "Quick add" })).toBeVisible()
   await page.getByLabel("Title *").fill(title)
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === "POST"),
     page.getByRole("button", { name: "Create task" }).click(),
   ])
+  await expect(page.getByRole("dialog", { name: "Quick add" })).toHaveCount(0)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText("open")
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   await page.locator("#detailLater").focus()
   await page.keyboard.press("Space")
 
   await page.getByRole("button", { name: "Save detail" }).click()
+  await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
+  await closeTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("later")
+  await openTaskDetail(page, title)
   await expect(page.locator("#detailStatus")).toContainText("open")
   await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
 
   await page.getByRole("button", { name: "Mark done" }).click()
+  await expect(page.getByRole("button", { name: "Reopen task" })).toBeVisible()
+  await closeTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("done")
   await expect(card).toContainText("later")
+  await openTaskDetail(page, title)
   await expect(page.locator("#detailStatus")).toContainText("done")
   await expect(page.getByRole("button", { name: "Reopen task" })).toBeVisible()
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await page.reload({ waitUntil: "domcontentloaded" })
+  await expect(page.locator("#detailTitle")).toHaveValue(title)
 
   await expect(card).toContainText("done")
   await expect(card).toContainText("later")
@@ -48,14 +76,18 @@ test("mark task done and reopen persists status while preserving later flag", as
   await expect(page.getByRole("button", { name: "Reopen task" })).toBeVisible()
 
   await page.getByRole("button", { name: "Reopen task" }).click()
+  await expect(page.getByRole("button", { name: "Mark done" })).toBeVisible()
+  await closeTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("open")
   await expect(card).toContainText("later")
+  await openTaskDetail(page, title)
   await expect(page.locator("#detailStatus")).toContainText("open")
   await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await page.reload({ waitUntil: "domcontentloaded" })
+  await expect(page.locator("#detailTitle")).toHaveValue(title)
 
   const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toBeVisible()

--- a/e2e/task-complete-reopen.spec.ts
+++ b/e2e/task-complete-reopen.spec.ts
@@ -6,8 +6,16 @@ test("mark task done and reopen persists status while preserving later flag", as
 
   await page.goto("/")
 
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: "domcontentloaded" }),
+    page.getByRole("link", { name: "Create task" }).click(),
+  ])
+  await expect(page.getByRole("dialog", { name: "Quick add" })).toBeVisible()
   await page.getByLabel("Title *").fill(title)
-  await page.getByRole("button", { name: "Create task" }).click()
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === "POST"),
+    page.getByRole("button", { name: "Create task" }).click(),
+  ])
 
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()

--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -4,16 +4,20 @@ async function showOnlyTask(page: import('@playwright/test').Page, title: string
   await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: 'domcontentloaded' })
 }
 
+async function openTaskDetail(page: import('@playwright/test').Page, title: string) {
+  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
+  await expect(page.locator('#detailTitle')).toHaveValue(title)
+}
+
 test('task detail renders attached links as clickable items and keeps one-per-line persistence', async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue34 Links ${unique}`
 
   await page.goto('/')
+  await showOnlyTask(page, title)
 
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
-    page.getByRole('link', { name: 'Create task' }).click(),
-  ])
+  await page.getByRole('link', { name: 'Create task' }).click()
   await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
   const quickAdd = page.locator('#quick-add')
   await quickAdd.getByLabel('Title *').fill(title)
@@ -21,12 +25,10 @@ test('task detail renders attached links as clickable items and keeps one-per-li
     page.waitForResponse((response) => response.request().method() === 'POST'),
     quickAdd.getByLabel('Title *').press('Enter'),
   ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
 
   await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
   await expect(page.getByLabel('Attached links')).toHaveCount(0)
@@ -64,10 +66,7 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await popup.close()
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
 
   await expect(page.locator('#detailLinks')).toHaveValue(
     'https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab',
@@ -80,17 +79,16 @@ test('task detail supports structured time session editing and explicit removal'
   const title = `Issue35 Sessions ${unique}`
 
   await page.goto('/')
+  await showOnlyTask(page, title)
 
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
-    page.getByRole('link', { name: 'Create task' }).click(),
-  ])
+  await page.getByRole('link', { name: 'Create task' }).click()
   await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
   await page.getByLabel('Title *').fill(title)
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
     page.getByRole('button', { name: 'Create task' }).click(),
   ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
 
   await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
@@ -107,10 +105,7 @@ test('task detail supports structured time session editing and explicit removal'
   ])
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
 
@@ -129,10 +124,7 @@ test('task detail supports structured time session editing and explicit removal'
   ])
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
 
   await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(startedAt)
   await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(endedAt)
@@ -148,10 +140,7 @@ test('task detail supports structured time session editing and explicit removal'
   ])
 
   await showOnlyTask(page, title)
-  await Promise.all([
-    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
-    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
-  ])
+  await openTaskDetail(page, title)
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(0)
   await expect(page.getByText('No time sessions yet.')).toBeVisible()

--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -1,28 +1,46 @@
 import { expect, test } from '@playwright/test'
 
+async function showOnlyTask(page: import('@playwright/test').Page, title: string) {
+  await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: 'domcontentloaded' })
+}
+
 test('task detail renders attached links as clickable items and keeps one-per-line persistence', async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue34 Links ${unique}`
 
   await page.goto('/')
 
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
+    page.getByRole('link', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
   const quickAdd = page.locator('#quick-add')
-  await quickAdd.scrollIntoViewIfNeeded()
   await quickAdd.getByLabel('Title *').fill(title)
-  await quickAdd.getByLabel('Title *').press('Enter')
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    quickAdd.getByLabel('Title *').press('Enter'),
+  ])
 
-  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
 
-  await expect(page.getByText('Task detail').first()).toBeVisible()
+  await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
   await expect(page.getByLabel('Attached links')).toHaveCount(0)
 
   await page
     .locator('#detailLinks')
     .fill('https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab')
 
-  await page.locator('#task-detail form').evaluate((form) => {
-    (form as HTMLFormElement).requestSubmit()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.locator('#task-detail form').evaluate((form) => {
+      (form as HTMLFormElement).requestSubmit()
+    }),
+  ])
 
   const attachedLinks = page.getByLabel('Attached links')
   const githubLink = attachedLinks.getByRole('link', {
@@ -45,8 +63,11 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await expect(popup).toHaveURL('https://github.com/vercel/next.js')
   await popup.close()
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
 
   await expect(page.locator('#detailLinks')).toHaveValue(
     'https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab',
@@ -60,17 +81,36 @@ test('task detail supports structured time session editing and explicit removal'
 
   await page.goto('/')
 
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: 'domcontentloaded' }),
+    page.getByRole('link', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
   await page.getByLabel('Title *').fill(title)
-  await page.getByRole('button', { name: 'Create task' }).click()
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.getByRole('button', { name: 'Create task' }).click(),
+  ])
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator('li', { hasText: title })
   await expect(card).toBeVisible()
 
-  await card.getByRole('button', { name: 'Start tracking' }).click()
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    card.getByRole('button', { name: 'Start tracking' }).click(),
+  ])
   await page.waitForTimeout(1100)
-  await card.getByRole('button', { name: 'Stop tracking' }).click()
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    card.getByRole('button', { name: 'Stop tracking' }).click(),
+  ])
 
-  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
 
@@ -81,12 +121,18 @@ test('task detail supports structured time session editing and explicit removal'
   await page.locator('#detailTimeSessionEndedAt-0').fill(endedAt)
   await page.locator('#detailTimeSessionDuration-0').fill('3600')
 
-  await page.locator('#task-detail form').evaluate((form) => {
-    (form as HTMLFormElement).requestSubmit()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.locator('#task-detail form').evaluate((form) => {
+      (form as HTMLFormElement).requestSubmit()
+    }),
+  ])
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
 
   await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(startedAt)
   await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(endedAt)
@@ -94,12 +140,18 @@ test('task detail supports structured time session editing and explicit removal'
 
   await page.locator('#detailTimeSessionRemove-0').check()
 
-  await page.locator('#task-detail form').evaluate((form) => {
-    (form as HTMLFormElement).requestSubmit()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.locator('#task-detail form').evaluate((form) => {
+      (form as HTMLFormElement).requestSubmit()
+    }),
+  ])
 
-  await page.reload()
-  await page.getByTestId('main-task-list').getByRole('link', { name: title }).click()
+  await showOnlyTask(page, title)
+  await Promise.all([
+    page.waitForURL(/taskId=/, { waitUntil: 'domcontentloaded' }),
+    page.getByTestId('main-task-list').getByRole('link', { name: title }).click(),
+  ])
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(0)
   await expect(page.getByText('No time sessions yet.')).toBeVisible()

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -7,9 +7,18 @@ function buildUnique(testName: string) {
 async function submitQuickAdd(page: import("@playwright/test").Page) {
   const createButton = page.getByRole("button", { name: "Create task" })
   await expect(createButton).toBeVisible()
-  await createButton.evaluate((element) => {
-    ;(element as HTMLButtonElement).click()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === "POST"),
+    createButton.click(),
+  ])
+}
+
+async function openQuickAdd(page: import("@playwright/test").Page) {
+  await Promise.all([
+    page.waitForURL(/quickAdd=1/, { waitUntil: "domcontentloaded" }),
+    page.getByRole("link", { name: "Create task" }).click(),
+  ])
+  await expect(page.getByRole("dialog", { name: "Quick add" })).toBeVisible()
 }
 
 async function saveTaskDetail(page: import("@playwright/test").Page) {
@@ -26,6 +35,7 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
 
   await page.goto("/")
 
+  await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
@@ -77,6 +87,7 @@ test("double start submission does not create duplicate running sessions", async
 
   await page.goto("/")
 
+  await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
@@ -101,6 +112,7 @@ test("double stop submission does not mutate ended session twice", async ({ page
 
   await page.goto("/")
 
+  await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
@@ -148,6 +160,7 @@ test("today totals include overlap for sessions that started before midnight", a
 
   await page.goto("/")
 
+  await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
@@ -178,6 +191,7 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
 
   await page.goto("/")
 
+  await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -11,22 +11,33 @@ async function submitQuickAdd(page: import("@playwright/test").Page) {
     page.waitForResponse((response) => response.request().method() === "POST"),
     createButton.click(),
   ])
+  await expect(page.getByRole("dialog", { name: "Quick add" })).toHaveCount(0)
 }
 
 async function openQuickAdd(page: import("@playwright/test").Page) {
-  await Promise.all([
-    page.waitForURL(/quickAdd=1/, { waitUntil: "domcontentloaded" }),
-    page.getByRole("link", { name: "Create task" }).click(),
-  ])
-  await expect(page.getByRole("dialog", { name: "Quick add" })).toBeVisible()
+  await page.getByRole("link", { name: "Create task" }).click()
+  const quickAdd = page.getByRole("dialog", { name: "Quick add" })
+  await expect(quickAdd).toBeVisible()
+  await expect(quickAdd.getByLabel("Title *")).toBeEditable()
+}
+
+async function showOnlyTask(page: import("@playwright/test").Page, title: string) {
+  await page.goto(`/?q=${encodeURIComponent(title)}`, { waitUntil: "domcontentloaded" })
 }
 
 async function saveTaskDetail(page: import("@playwright/test").Page) {
   const saveButton = page.getByRole("button", { name: "Save detail" })
   await expect(saveButton).toBeVisible()
-  await saveButton.evaluate((element) => {
-    ;(element as HTMLButtonElement).click()
-  })
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === "POST"),
+    saveButton.click(),
+  ])
+}
+
+async function openTaskDetail(page: import("@playwright/test").Page, title: string) {
+  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await expect(page.getByRole("dialog", { name: "Task detail" })).toBeVisible()
+  await expect(page.locator("#detailTitle")).toHaveValue(title)
 }
 
 test("start, stop, persist, and edit task time sessions", async ({ page }, testInfo) => {
@@ -34,11 +45,13 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   const title = `Issue10 Time Tracking ${unique}`
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
   await expect(card).toContainText("Stopped")
@@ -53,7 +66,7 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   await card.getByRole("button", { name: "Stop tracking" }).click()
   await expect(card).toContainText("Stopped")
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -66,15 +79,16 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   await page.locator("#detailTimeSessionDuration-0").fill("")
   await saveTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("Total: 2m")
 
-  await page.reload()
+  await page.reload({ waitUntil: "domcontentloaded" })
 
   const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toContainText("Stopped")
   await expect(persistedCard).toContainText("Total: 2m")
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
   await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(correctedEndedAt.toISOString())
 
@@ -86,11 +100,13 @@ test("double start submission does not create duplicate running sessions", async
   const title = `Issue10 Double Start ${unique}`
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
@@ -98,7 +114,7 @@ test("double start submission does not create duplicate running sessions", async
 
   await expect(card.getByRole("button", { name: "Stop tracking" })).toBeVisible({ timeout: 10000 })
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -111,11 +127,13 @@ test("double stop submission does not mutate ended session twice", async ({ page
   const title = `Issue10 Double Stop ${unique}`
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
@@ -127,7 +145,7 @@ test("double stop submission does not mutate ended session twice", async ({ page
   await card.getByRole("button", { name: "Stop tracking" }).dblclick()
   await expect(card).toContainText("Stopped")
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
@@ -159,11 +177,13 @@ test("today totals include overlap for sessions that started before midnight", a
   const endedAt = new Date(midnight.getTime() + 10 * 60 * 1000)
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(card).toBeVisible()
 
@@ -172,7 +192,7 @@ test("today totals include overlap for sessions that started before midnight", a
   await page.waitForTimeout(1100)
   await card.getByRole("button", { name: "Stop tracking" }).click()
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
   await page.locator("#detailTimeSessionStartedAt-0").fill(startedAt.toISOString())
@@ -181,6 +201,7 @@ test("today totals include overlap for sessions that started before midnight", a
 
   await saveTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("Today: 10m")
   await expect(card).toContainText("Total: 20m")
 })
@@ -190,11 +211,13 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   const title = `Issue10 EndedAt Recompute ${unique}`
 
   await page.goto("/")
+  await showOnlyTask(page, title)
 
   await openQuickAdd(page)
   await page.getByLabel("Title *").fill(title)
   await submitQuickAdd(page)
 
+  await showOnlyTask(page, title)
   const card = page.getByTestId('main-task-list').locator("li", { hasText: title })
 
   await card.getByRole("button", { name: "Start tracking" }).click()
@@ -203,7 +226,7 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   await page.waitForTimeout(1200)
   await card.getByRole("button", { name: "Stop tracking" }).click()
 
-  await page.getByTestId('main-task-list').getByRole("link", { name: title }).click()
+  await openTaskDetail(page, title)
 
   const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
   const startedAt = new Date(startedAtRaw)
@@ -213,9 +236,10 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   await page.locator("#detailTimeSessionDuration-0").fill("1")
   await saveTaskDetail(page)
 
+  await showOnlyTask(page, title)
   await expect(card).toContainText("Total: 10m")
 
-  await page.reload()
+  await page.reload({ waitUntil: "domcontentloaded" })
   const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toContainText("Total: 10m")
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { Download, Plus } from 'lucide-react';
@@ -20,12 +19,15 @@ import {
 	startTaskTimeTracking,
 	stopTaskTimeTracking
 } from '@/lib/server/time-tracking';
+import { QuickAddDialogContent } from '@/components/quick-add-dialog-content';
 import { RecentlyOpenedTasks } from '@/components/recently-opened-tasks';
+import { TaskDetailDialogContent } from '@/components/task-detail-dialog-content';
 import { TaskFilters } from '@/components/task-filters';
 import { TaskList } from '@/components/task-list';
 import { TaskSearchInput } from '@/components/task-search-input';
 import { SOURCE_LABELS } from '@/components/task-display-helpers';
 import { TodayWorkedSummary } from '@/components/today-worked-summary';
+import { UrlDialog } from '@/components/url-dialog';
 import { Button } from '@/components/ui/button';
 import {
 	Card,
@@ -34,16 +36,6 @@ import {
 	CardHeader,
 	CardTitle
 } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-	Empty,
-	EmptyDescription,
-	EmptyHeader,
-	EmptyTitle
-} from '@/components/ui/empty';
-import { Input } from '@/components/ui/input';
-import { SelectFormField } from '@/components/select-form-field';
-import { Textarea } from '@/components/ui/textarea';
 
 const STATUS_OPTIONS = [
 	'open',
@@ -56,6 +48,16 @@ const STATUS_OPTIONS = [
 
 const TODAY_WORKED_SUMMARY_VISIBLE_LIMIT = 5;
 
+function getSafeRedirectPath(value: FormDataEntryValue | null) {
+	const redirectPath = String(value ?? '').trim();
+
+	if (!redirectPath.startsWith('/') || redirectPath.startsWith('//')) {
+		return '/';
+	}
+
+	return redirectPath;
+}
+
 async function createTaskAction(formData: FormData) {
 	'use server';
 
@@ -65,6 +67,7 @@ async function createTaskAction(formData: FormData) {
 	const tagsRaw = String(formData.get('tags') ?? '');
 	const peopleRaw = String(formData.get('people') ?? '');
 	const startTrackingNow = formData.get('startTrackingNow') === 'on';
+	const returnTo = getSafeRedirectPath(formData.get('returnTo'));
 
 	const tags = tagsRaw
 		.split(',')
@@ -86,6 +89,7 @@ async function createTaskAction(formData: FormData) {
 	});
 
 	revalidatePath('/');
+	redirect(returnTo);
 }
 
 async function startTrackingAction(formData: FormData) {
@@ -206,6 +210,7 @@ async function updateTaskDetailAction(taskId: number, formData: FormData) {
 	const linksRaw = String(formData.get('detailLinks') ?? '');
 	const tagsRaw = String(formData.get('detailTags') ?? '');
 	const peopleRaw = String(formData.get('detailPeople') ?? '');
+	const detailReturnTo = getSafeRedirectPath(formData.get('detailReturnTo'));
 
 	if (!STATUS_OPTIONS.includes(status as (typeof STATUS_OPTIONS)[number])) {
 		throw new Error('Invalid status');
@@ -232,30 +237,26 @@ async function updateTaskDetailAction(taskId: number, formData: FormData) {
 	});
 
 	revalidatePath('/');
-	redirect(`/?taskId=${taskId}#task-detail`);
+	redirect(detailReturnTo);
 }
 
-function formatTimestamp(value: Date) {
-	return new Intl.DateTimeFormat(undefined, {
-		dateStyle: 'medium',
-		timeStyle: 'short'
-	}).format(value);
+function getFirstParam(
+	params: Record<string, string | string[] | undefined>,
+	key: string
+) {
+	const value = params[key];
+	return Array.isArray(value) ? value[0] : value;
 }
 
-function getLinkDomainHint(url: string) {
-	try {
-		return new URL(url).hostname.replace(/^www\./, '');
-	} catch {
-		return null;
-	}
-}
+function buildHref(baseParams: URLSearchParams, values: Record<string, string>) {
+	const params = new URLSearchParams(baseParams);
 
-function truncateLinkLabel(url: string, maxLength = 96) {
-	if (url.length <= maxLength) {
-		return url;
+	for (const [key, value] of Object.entries(values)) {
+		params.set(key, value);
 	}
 
-	return `${url.slice(0, maxLength).trimEnd()}...`;
+	const query = params.toString();
+	return query ? `/?${query}` : '/';
 }
 
 export default async function Home({
@@ -264,19 +265,15 @@ export default async function Home({
 	searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
 	const params = await searchParams;
-	const taskIdParam =
-		Array.isArray(params.taskId) ? params.taskId[0] : params.taskId;
-	const queryParam = Array.isArray(params.q) ? params.q[0] : params.q;
-	const statusParam =
-		Array.isArray(params.status) ? params.status[0] : params.status;
-	const laterParam =
-		Array.isArray(params.later) ? params.later[0] : params.later;
-	const personParam =
-		Array.isArray(params.person) ? params.person[0] : params.person;
-	const tagParam = Array.isArray(params.tag) ? params.tag[0] : params.tag;
-	const timeParam = Array.isArray(params.time) ? params.time[0] : params.time;
-	const sourceParam =
-		Array.isArray(params.source) ? params.source[0] : params.source;
+	const taskIdParam = getFirstParam(params, 'taskId');
+	const queryParam = getFirstParam(params, 'q');
+	const statusParam = getFirstParam(params, 'status');
+	const laterParam = getFirstParam(params, 'later');
+	const personParam = getFirstParam(params, 'person');
+	const tagParam = getFirstParam(params, 'tag');
+	const timeParam = getFirstParam(params, 'time');
+	const sourceParam = getFirstParam(params, 'source');
+	const quickAddParam = getFirstParam(params, 'quickAdd');
 
 	const selectedTaskId = Number.parseInt(taskIdParam ?? '', 10);
 
@@ -391,9 +388,17 @@ export default async function Home({
 		taskLinkParams.set('source', filters.source);
 	}
 
+	const taskListParams = taskLinkParams.toString();
+	const closeHref = buildHref(taskLinkParams, {});
+	const openQuickAddHref = buildHref(taskLinkParams, { quickAdd: '1' });
+	const selectedTaskHref =
+		selectedTask ?
+			`${buildHref(taskLinkParams, { taskId: String(selectedTask.id) })}#task-detail`
+		:	closeHref;
+
 	return (
 		<div className='mx-auto min-h-screen w-full max-w-7xl px-6 py-8 lg:px-10'>
-			<main className='grid gap-6 lg:grid-cols-[1fr_1fr]'>
+			<main className='grid gap-6 lg:grid-cols-[minmax(320px,0.82fr)_minmax(0,1.18fr)]'>
 				<section
 					className='space-y-6'
 					aria-label='Task workspace'>
@@ -408,7 +413,7 @@ export default async function Home({
 							</CardDescription>
 						</CardHeader>
 						<CardContent className='space-y-5'>
-							<div className='grid gap-4 lg:grid-cols-[1fr_auto]'>
+							<div className='grid gap-4'>
 								<div className='space-y-2'>
 									<label
 										htmlFor='task-search'
@@ -418,11 +423,11 @@ export default async function Home({
 									<TaskSearchInput />
 								</div>
 
-								<div className='flex flex-wrap items-end gap-2'>
+								<div className='flex flex-wrap gap-2'>
 									<Button
 										asChild
-										className='w-full lg:w-auto'>
-										<a href='#quick-add'>
+										className='w-full sm:w-auto'>
+										<a href={openQuickAddHref}>
 											<Plus
 												aria-hidden='true'
 												className='size-4'
@@ -433,7 +438,7 @@ export default async function Home({
 									<Button
 										asChild
 										variant='outline'
-										className='w-full lg:w-auto'>
+										className='w-full sm:w-auto'>
 										<a href='/api/exports/tasks/open'>
 											<Download
 												aria-hidden='true'
@@ -463,439 +468,50 @@ export default async function Home({
 
 					<RecentlyOpenedTasks
 						recentlyOpenedTasks={recentlyOpenedTasks}
-						taskLinkParams={taskLinkParams.toString()}
-					/>
-
-					<TaskList
-						selectedTaskId={selectedTask?.id ?? null}
-						startTrackingAction={startTrackingAction}
-						stopTrackingAction={stopTrackingAction}
-						taskLinkParams={taskLinkParams.toString()}
-						tasks={tasks}
+						taskLinkParams={taskListParams}
 					/>
 				</section>
 
-				<aside
-					className='space-y-6 lg:sticky lg:top-8 lg:self-start'
-					aria-label='Task detail and quick add'>
-					<Card id='task-detail'>
-						<CardHeader className='border-b border-border'>
-							<CardTitle className='text-base tracking-tight'>
-								Task detail
-							</CardTitle>
-							<CardDescription>
-								{selectedTask ?
-									'Phase 1 task payload fields are editable and persisted in MySQL.'
-								:	'Select a task title from the list to open details.'}
-							</CardDescription>
-						</CardHeader>
-						<CardContent>
-							{selectedTask ?
-								<form
-									action={updateTaskDetailAction.bind(null, selectedTask.id)}
-									className='space-y-4'>
-									<div className='space-y-1.5'>
-										<label
-											htmlFor='detailTitle'
-											className='text-sm font-medium'>
-											Title
-										</label>
-										<Input
-											id='detailTitle'
-											name='detailTitle'
-											defaultValue={selectedTask.title}
-											required
-										/>
-									</div>
-
-									<div className='grid gap-3 sm:grid-cols-2'>
-										<div className='space-y-1.5'>
-											<label
-												htmlFor='detailStatus'
-												className='text-sm font-medium'>
-												Status
-											</label>
-											<SelectFormField
-												id='detailStatus'
-												name='detailStatus'
-												ariaLabel='Status'
-												value={selectedTask.status}
-												placeholder='Status'
-												triggerClassName='w-full rounded-md'
-												options={STATUS_OPTIONS.map((statusOption) => ({
-													value: statusOption,
-													label: statusOption
-												}))}
-											/>
-										</div>
-
-										<div className='flex items-end'>
-											<label className='flex items-center gap-2 text-sm'>
-												<Checkbox
-													id='detailLater'
-													name='detailLater'
-													defaultChecked={selectedTask.later}
-												/>
-												Later
-											</label>
-										</div>
-									</div>
-
-									<div className='space-y-1.5'>
-										<label
-											htmlFor='detailNote'
-											className='text-sm font-medium'>
-											Note (markdown text)
-										</label>
-										<Textarea
-											id='detailNote'
-											name='detailNote'
-											defaultValue={selectedTask.note ?? ''}
-											className='min-h-28'
-										/>
-										{selectedTask.note ?
-											<pre className='max-h-24 overflow-auto rounded-md border border-border bg-muted/20 p-2 text-xs text-muted-foreground'>
-												{selectedTask.note}
-											</pre>
-										:	null}
-									</div>
-
-									<div className='space-y-1.5'>
-										<label
-											htmlFor='detailLinks'
-											className='text-sm font-medium'>
-											Links (one URL per line)
-										</label>
-										<Textarea
-											id='detailLinks'
-											name='detailLinks'
-											defaultValue={selectedTask.links.join('\n')}
-											className='min-h-24'
-										/>
-										{selectedTask.links.length > 0 ?
-											<ul
-												className='space-y-1 rounded-md border border-border bg-muted/20 p-2 text-sm'
-												aria-label='Attached links'>
-												{selectedTask.links.map((link) => {
-													const domainHint = getLinkDomainHint(link);
-
-													return (
-														<li
-															key={link}
-															className='flex items-center justify-between gap-3'>
-															<a
-																href={link}
-																target='_blank'
-																rel='noreferrer noopener'
-																className='truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
-																{truncateLinkLabel(link)}
-															</a>
-															{domainHint ?
-																<span className='shrink-0 text-xs text-muted-foreground'>
-																	{domainHint}
-																</span>
-															:	null}
-														</li>
-													);
-												})}
-											</ul>
-										:	null}
-									</div>
-
-									<div className='space-y-1.5'>
-										<label
-											htmlFor='detailTags'
-											className='text-sm font-medium'>
-											Tags (comma-separated)
-										</label>
-										<Input
-											id='detailTags'
-											name='detailTags'
-											defaultValue={selectedTask.tags.join(', ')}
-										/>
-									</div>
-
-									<div className='space-y-1.5'>
-										<label
-											htmlFor='detailPeople'
-											className='text-sm font-medium'>
-											Person references (comma-separated)
-										</label>
-										<Input
-											id='detailPeople'
-											name='detailPeople'
-											defaultValue={selectedTask.people.join(', ')}
-										/>
-									</div>
-
-									<div className='space-y-2'>
-										<div className='space-y-1.5'>
-											<p className='text-sm font-medium'>Time sessions</p>
-											<p className='text-xs text-muted-foreground'>
-												Edit each session directly using ISO date-time values.
-											</p>
-										</div>
-										<input
-											type='hidden'
-											name='detailTimeSessionCount'
-											value={selectedTask.timeSessions.length}
-										/>
-										{selectedTask.timeSessions.length > 0 ?
-											<ul
-												className='space-y-2'
-												aria-label='Time sessions'>
-												{selectedTask.timeSessions.map((session, index) => (
-													<li
-														key={'time-session-' + index}
-														className='rounded-md border border-border bg-muted/20 p-3'
-														data-testid='time-session-row'>
-														<div className='grid gap-2 sm:grid-cols-3'>
-															<div className='space-y-1'>
-																<label
-																	htmlFor={
-																		'detailTimeSessionStartedAt-' + index
-																	}
-																	className='text-xs font-medium text-muted-foreground'>
-																	Started at
-																</label>
-																<Input
-																	id={'detailTimeSessionStartedAt-' + index}
-																	name={'detailTimeSessionStartedAt_' + index}
-																	defaultValue={session.startedAt.toISOString()}
-																	className='font-mono text-xs'
-																	required
-																/>
-															</div>
-															<div className='space-y-1'>
-																<label
-																	htmlFor={'detailTimeSessionEndedAt-' + index}
-																	className='text-xs font-medium text-muted-foreground'>
-																	Ended at
-																</label>
-																<Input
-																	id={'detailTimeSessionEndedAt-' + index}
-																	name={'detailTimeSessionEndedAt_' + index}
-																	defaultValue={
-																		session.endedAt ?
-																			session.endedAt.toISOString()
-																		:	''
-																	}
-																	className='font-mono text-xs'
-																/>
-															</div>
-															<div className='space-y-1'>
-																<label
-																	htmlFor={'detailTimeSessionDuration-' + index}
-																	className='text-xs font-medium text-muted-foreground'>
-																	Duration (seconds)
-																</label>
-																<Input
-																	id={'detailTimeSessionDuration-' + index}
-																	name={'detailTimeSessionDuration_' + index}
-																	defaultValue={session.durationSeconds ?? ''}
-																	className='font-mono text-xs'
-																	inputMode='numeric'
-																/>
-															</div>
-														</div>
-														<div className='mt-2'>
-															<label
-																htmlFor={'detailTimeSessionRemove-' + index}
-																className='inline-flex items-center gap-2 text-xs text-muted-foreground'>
-																<input
-																	id={'detailTimeSessionRemove-' + index}
-																	type='checkbox'
-																	name={'detailTimeSessionRemove_' + index}
-																	value='1'
-																	className='size-4 rounded border-border align-middle'
-																/>
-																Remove this session on save
-															</label>
-														</div>
-													</li>
-												))}
-											</ul>
-										:	<p className='rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground'>
-												No time sessions yet.
-											</p>
-										}
-									</div>
-
-									<dl className='space-y-1 rounded-md border border-border bg-muted/20 p-3 text-xs'>
-										<div className='flex justify-between gap-3'>
-											<dt className='text-muted-foreground'>Created</dt>
-											<dd>
-												<time dateTime={selectedTask.createdAt.toISOString()}>
-													{formatTimestamp(selectedTask.createdAt)}
-												</time>
-											</dd>
-										</div>
-										<div className='flex justify-between gap-3'>
-											<dt className='text-muted-foreground'>Updated</dt>
-											<dd>
-												<time dateTime={selectedTask.updatedAt.toISOString()}>
-													{formatTimestamp(selectedTask.updatedAt)}
-												</time>
-											</dd>
-										</div>
-									</dl>
-
-									<div className='flex flex-wrap gap-2'>
-										<Button
-											type='submit'
-											className='flex-1'>
-											Save detail
-										</Button>
-										<Button
-											asChild
-											type='button'
-											variant='outline'>
-											<a href={`/api/exports/task/${selectedTask.id}/markdown`}>
-												<Download
-													aria-hidden='true'
-													className='size-4'
-												/>
-												Export markdown
-											</a>
-										</Button>
-										{selectedTask.status === 'done' ?
-											<Button
-												type='submit'
-												name='detailStatusTransition'
-												value='reopen'
-												variant='secondary'>
-												Reopen task
-											</Button>
-										:	<Button
-												type='submit'
-												name='detailStatusTransition'
-												value='done'
-												variant='secondary'>
-												Mark done
-											</Button>
-										}
-										<Button
-											asChild
-											type='button'
-											variant='outline'>
-											<Link href='/'>Close</Link>
-										</Button>
-									</div>
-								</form>
-							:	<Empty>
-									<EmptyHeader>
-										<EmptyTitle>No task selected</EmptyTitle>
-										<EmptyDescription>
-											Choose a task from the list to view and edit detail
-											fields.
-										</EmptyDescription>
-									</EmptyHeader>
-								</Empty>
-							}
-						</CardContent>
-					</Card>
-
-					<Card
-						id='quick-add'
-						aria-label='Quick add'>
-						<CardHeader className='border-b border-border'>
-							<CardTitle className='text-base tracking-tight'>
-								Quick add
-							</CardTitle>
-							<CardDescription>Only title is required.</CardDescription>
-						</CardHeader>
-						<CardContent>
-							<form
-								action={createTaskAction}
-								className='space-y-4'>
-								<div className='space-y-1.5'>
-									<label
-										htmlFor='title'
-										className='text-sm font-medium'>
-										Title <span className='text-destructive'>*</span>
-									</label>
-									<Input
-										id='title'
-										name='title'
-										required
-										placeholder='Add task title'
-									/>
-								</div>
-
-								<div className='space-y-1.5'>
-									<label
-										htmlFor='note'
-										className='text-sm font-medium'>
-										Note (optional)
-									</label>
-									<Textarea
-										id='note'
-										name='note'
-										placeholder='Short markdown-friendly note'
-										className='min-h-24'
-									/>
-								</div>
-
-								<div className='space-y-1.5'>
-									<label
-										htmlFor='firstLink'
-										className='text-sm font-medium'>
-										First link (optional)
-									</label>
-									<Input
-										id='firstLink'
-										name='firstLink'
-										type='url'
-										placeholder='https://github.com/...'
-									/>
-								</div>
-
-								<div className='space-y-1.5'>
-									<label
-										htmlFor='tags'
-										className='text-sm font-medium'>
-										First tags (optional)
-									</label>
-									<Input
-										id='tags'
-										name='tags'
-										placeholder='bug, frontend, review'
-									/>
-								</div>
-
-								<div className='space-y-1.5'>
-									<label
-										htmlFor='people'
-										className='text-sm font-medium'>
-										First person references (optional)
-									</label>
-									<Input
-										id='people'
-										name='people'
-										placeholder='@anna, @max'
-									/>
-								</div>
-
-								<label
-									className='flex items-center gap-2 text-sm'
-									htmlFor='startTrackingNow'>
-									<Checkbox
-										id='startTrackingNow'
-										name='startTrackingNow'
-									/>
-									Start time tracking now
-								</label>
-
-								<Button
-									type='submit'
-									className='w-full'>
-									Create task
-								</Button>
-							</form>
-						</CardContent>
-					</Card>
-				</aside>
+				<section
+					className='lg:sticky lg:top-8 lg:self-start'
+					aria-label='Task list'>
+					<TaskList
+						openQuickAddHref={openQuickAddHref}
+						selectedTaskId={selectedTask?.id ?? null}
+						startTrackingAction={startTrackingAction}
+						stopTrackingAction={stopTrackingAction}
+						taskLinkParams={taskListParams}
+						tasks={tasks}
+					/>
+				</section>
 			</main>
+
+			<UrlDialog
+				open={quickAddParam === '1'}
+				closeHref={closeHref}
+				contentClassName='max-h-[calc(100vh-4rem)] gap-0 overflow-hidden p-0 sm:max-w-xl'
+				contentId='quick-add'>
+				<QuickAddDialogContent
+					closeHref={closeHref}
+					createTaskAction={createTaskAction}
+				/>
+			</UrlDialog>
+
+			{selectedTask ?
+				<UrlDialog
+					open={true}
+					closeHref={closeHref}
+					contentClassName='max-h-[calc(100vh-4rem)] gap-0 overflow-hidden p-0 sm:max-w-3xl'
+					contentId='task-detail'>
+					<TaskDetailDialogContent
+						closeHref={closeHref}
+						detailReturnTo={selectedTaskHref}
+						selectedTask={selectedTask}
+						statusOptions={STATUS_OPTIONS}
+						updateTaskDetailAction={updateTaskDetailAction}
+					/>
+				</UrlDialog>
+			:	null}
 		</div>
 	);
 }

--- a/src/components/quick-add-dialog-content.tsx
+++ b/src/components/quick-add-dialog-content.tsx
@@ -1,0 +1,132 @@
+import { Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+	DialogDescription,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+type CreateTaskAction = (formData: FormData) => Promise<void>;
+
+type QuickAddDialogContentProps = {
+	closeHref: string;
+	createTaskAction: CreateTaskAction;
+};
+
+export function QuickAddDialogContent({
+	closeHref,
+	createTaskAction
+}: QuickAddDialogContentProps) {
+	return (
+		<>
+			<DialogHeader className='border-b border-border px-6 py-5'>
+				<DialogTitle>Quick add</DialogTitle>
+				<DialogDescription>Only title is required.</DialogDescription>
+			</DialogHeader>
+
+			<div className='overflow-y-auto px-6 py-5'>
+				<form
+					action={createTaskAction}
+					className='space-y-4'>
+					<input
+						type='hidden'
+						name='returnTo'
+						value={closeHref}
+					/>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='title'
+							className='text-sm font-medium'>
+							Title <span className='text-destructive'>*</span>
+						</label>
+						<Input
+							id='title'
+							name='title'
+							required
+							placeholder='Add task title'
+						/>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='note'
+							className='text-sm font-medium'>
+							Note (optional)
+						</label>
+						<Textarea
+							id='note'
+							name='note'
+							placeholder='Short markdown-friendly note'
+							className='min-h-24'
+						/>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='firstLink'
+							className='text-sm font-medium'>
+							First link (optional)
+						</label>
+						<Input
+							id='firstLink'
+							name='firstLink'
+							type='url'
+							placeholder='https://github.com/...'
+						/>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='tags'
+							className='text-sm font-medium'>
+							First tags (optional)
+						</label>
+						<Input
+							id='tags'
+							name='tags'
+							placeholder='bug, frontend, review'
+						/>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='people'
+							className='text-sm font-medium'>
+							First person references (optional)
+						</label>
+						<Input
+							id='people'
+							name='people'
+							placeholder='@anna, @max'
+						/>
+					</div>
+
+					<label
+						className='flex items-center gap-2 text-sm'
+						htmlFor='startTrackingNow'>
+						<Checkbox
+							id='startTrackingNow'
+							name='startTrackingNow'
+						/>
+						Start time tracking now
+					</label>
+
+					<Button
+						type='submit'
+						className='w-full'>
+						<Plus
+							aria-hidden='true'
+							className='size-4'
+						/>
+						Create task
+					</Button>
+				</form>
+			</div>
+		</>
+	);
+}

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -1,0 +1,365 @@
+import Link from 'next/link';
+import { Download } from 'lucide-react';
+
+import type { TaskDetail } from '@/lib/server/tasks';
+import { SelectFormField } from '@/components/select-form-field';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+	DialogDescription,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+type UpdateTaskDetailAction = (
+	taskId: number,
+	formData: FormData
+) => Promise<void>;
+
+type TaskDetailDialogContentProps = {
+	closeHref: string;
+	detailReturnTo: string;
+	selectedTask: TaskDetail;
+	statusOptions: readonly string[];
+	updateTaskDetailAction: UpdateTaskDetailAction;
+};
+
+function formatTimestamp(value: Date) {
+	return new Intl.DateTimeFormat(undefined, {
+		dateStyle: 'medium',
+		timeStyle: 'short'
+	}).format(value);
+}
+
+function getLinkDomainHint(url: string) {
+	try {
+		return new URL(url).hostname.replace(/^www\./, '');
+	} catch {
+		return null;
+	}
+}
+
+function truncateLinkLabel(url: string, maxLength = 96) {
+	if (url.length <= maxLength) {
+		return url;
+	}
+
+	return `${url.slice(0, maxLength).trimEnd()}...`;
+}
+
+export function TaskDetailDialogContent({
+	closeHref,
+	detailReturnTo,
+	selectedTask,
+	statusOptions,
+	updateTaskDetailAction
+}: TaskDetailDialogContentProps) {
+	return (
+		<>
+			<DialogHeader className='border-b border-border px-6 py-5'>
+				<DialogTitle>Task detail</DialogTitle>
+				<DialogDescription>
+					Phase 1 task payload fields are editable and persisted in MySQL.
+				</DialogDescription>
+			</DialogHeader>
+
+			<div className='overflow-y-auto px-6 py-5'>
+				<form
+					action={updateTaskDetailAction.bind(null, selectedTask.id)}
+					className='space-y-4'>
+					<input
+						type='hidden'
+						name='detailReturnTo'
+						value={detailReturnTo}
+					/>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='detailTitle'
+							className='text-sm font-medium'>
+							Title
+						</label>
+						<Input
+							id='detailTitle'
+							name='detailTitle'
+							defaultValue={selectedTask.title}
+							required
+						/>
+					</div>
+
+					<div className='grid gap-3 sm:grid-cols-2'>
+						<div className='space-y-1.5'>
+							<label
+								htmlFor='detailStatus'
+								className='text-sm font-medium'>
+								Status
+							</label>
+							<SelectFormField
+								id='detailStatus'
+								name='detailStatus'
+								ariaLabel='Status'
+								value={selectedTask.status}
+								placeholder='Status'
+								triggerClassName='w-full rounded-md'
+								options={statusOptions.map((statusOption) => ({
+									value: statusOption,
+									label: statusOption
+								}))}
+							/>
+						</div>
+
+						<div className='flex items-end'>
+							<label className='flex items-center gap-2 text-sm'>
+								<Checkbox
+									id='detailLater'
+									name='detailLater'
+									defaultChecked={selectedTask.later}
+								/>
+								Later
+							</label>
+						</div>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='detailNote'
+							className='text-sm font-medium'>
+							Note (markdown text)
+						</label>
+						<Textarea
+							id='detailNote'
+							name='detailNote'
+							defaultValue={selectedTask.note ?? ''}
+							className='min-h-28'
+						/>
+						{selectedTask.note ?
+							<pre className='max-h-24 overflow-auto rounded-md border border-border bg-muted/20 p-2 text-xs text-muted-foreground'>
+								{selectedTask.note}
+							</pre>
+						:	null}
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='detailLinks'
+							className='text-sm font-medium'>
+							Links (one URL per line)
+						</label>
+						<Textarea
+							id='detailLinks'
+							name='detailLinks'
+							defaultValue={selectedTask.links.join('\n')}
+							className='min-h-24'
+						/>
+						{selectedTask.links.length > 0 ?
+							<ul
+								className='space-y-1 rounded-md border border-border bg-muted/20 p-2 text-sm'
+								aria-label='Attached links'>
+								{selectedTask.links.map((link) => {
+									const domainHint = getLinkDomainHint(link);
+
+									return (
+										<li
+											key={link}
+											className='flex items-center justify-between gap-3'>
+											<a
+												href={link}
+												target='_blank'
+												rel='noreferrer noopener'
+												className='truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
+												{truncateLinkLabel(link)}
+											</a>
+											{domainHint ?
+												<span className='shrink-0 text-xs text-muted-foreground'>
+													{domainHint}
+												</span>
+											:	null}
+										</li>
+									);
+								})}
+							</ul>
+						:	null}
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='detailTags'
+							className='text-sm font-medium'>
+							Tags (comma-separated)
+						</label>
+						<Input
+							id='detailTags'
+							name='detailTags'
+							defaultValue={selectedTask.tags.join(', ')}
+						/>
+					</div>
+
+					<div className='space-y-1.5'>
+						<label
+							htmlFor='detailPeople'
+							className='text-sm font-medium'>
+							Person references (comma-separated)
+						</label>
+						<Input
+							id='detailPeople'
+							name='detailPeople'
+							defaultValue={selectedTask.people.join(', ')}
+						/>
+					</div>
+
+					<div className='space-y-2'>
+						<div className='space-y-1.5'>
+							<p className='text-sm font-medium'>Time sessions</p>
+							<p className='text-xs text-muted-foreground'>
+								Edit each session directly using ISO date-time values.
+							</p>
+						</div>
+						<input
+							type='hidden'
+							name='detailTimeSessionCount'
+							value={selectedTask.timeSessions.length}
+						/>
+						{selectedTask.timeSessions.length > 0 ?
+							<ul
+								className='space-y-2'
+								aria-label='Time sessions'>
+								{selectedTask.timeSessions.map((session, index) => (
+									<li
+										key={session.id}
+										className='rounded-md border border-border bg-muted/20 p-3'
+										data-testid='time-session-row'>
+										<div className='grid gap-2 sm:grid-cols-3'>
+											<div className='space-y-1'>
+												<label
+													htmlFor={'detailTimeSessionStartedAt-' + index}
+													className='text-xs font-medium text-muted-foreground'>
+													Started at
+												</label>
+												<Input
+													id={'detailTimeSessionStartedAt-' + index}
+													name={'detailTimeSessionStartedAt_' + index}
+													defaultValue={session.startedAt.toISOString()}
+													className='font-mono text-xs'
+													required
+												/>
+											</div>
+											<div className='space-y-1'>
+												<label
+													htmlFor={'detailTimeSessionEndedAt-' + index}
+													className='text-xs font-medium text-muted-foreground'>
+													Ended at
+												</label>
+												<Input
+													id={'detailTimeSessionEndedAt-' + index}
+													name={'detailTimeSessionEndedAt_' + index}
+													defaultValue={
+														session.endedAt ? session.endedAt.toISOString() : ''
+													}
+													className='font-mono text-xs'
+												/>
+											</div>
+											<div className='space-y-1'>
+												<label
+													htmlFor={'detailTimeSessionDuration-' + index}
+													className='text-xs font-medium text-muted-foreground'>
+													Duration (seconds)
+												</label>
+												<Input
+													id={'detailTimeSessionDuration-' + index}
+													name={'detailTimeSessionDuration_' + index}
+													defaultValue={session.durationSeconds ?? ''}
+													className='font-mono text-xs'
+													inputMode='numeric'
+												/>
+											</div>
+										</div>
+										<div className='mt-2'>
+											<label
+												htmlFor={'detailTimeSessionRemove-' + index}
+												className='inline-flex items-center gap-2 text-xs text-muted-foreground'>
+												<input
+													id={'detailTimeSessionRemove-' + index}
+													type='checkbox'
+													name={'detailTimeSessionRemove_' + index}
+													value='1'
+													className='size-4 rounded border-border align-middle'
+												/>
+												Remove this session on save
+											</label>
+										</div>
+									</li>
+								))}
+							</ul>
+						:	<p className='rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground'>
+								No time sessions yet.
+							</p>
+						}
+					</div>
+
+					<dl className='space-y-1 rounded-md border border-border bg-muted/20 p-3 text-xs'>
+						<div className='flex justify-between gap-3'>
+							<dt className='text-muted-foreground'>Created</dt>
+							<dd>
+								<time dateTime={selectedTask.createdAt.toISOString()}>
+									{formatTimestamp(selectedTask.createdAt)}
+								</time>
+							</dd>
+						</div>
+						<div className='flex justify-between gap-3'>
+							<dt className='text-muted-foreground'>Updated</dt>
+							<dd>
+								<time dateTime={selectedTask.updatedAt.toISOString()}>
+									{formatTimestamp(selectedTask.updatedAt)}
+								</time>
+							</dd>
+						</div>
+					</dl>
+
+					<div className='flex flex-wrap gap-2'>
+						<Button
+							type='submit'
+							className='flex-1'>
+							Save detail
+						</Button>
+						<Button
+							asChild
+							type='button'
+							variant='outline'>
+							<a href={`/api/exports/task/${selectedTask.id}/markdown`}>
+								<Download
+									aria-hidden='true'
+									className='size-4'
+								/>
+								Export markdown
+							</a>
+						</Button>
+						{selectedTask.status === 'done' ?
+							<Button
+								type='submit'
+								name='detailStatusTransition'
+								value='reopen'
+								variant='secondary'>
+								Reopen task
+							</Button>
+						:	<Button
+								type='submit'
+								name='detailStatusTransition'
+								value='done'
+								variant='secondary'>
+								Mark done
+							</Button>
+						}
+						<Button
+							asChild
+							type='button'
+							variant='outline'>
+							<Link href={closeHref}>Close</Link>
+						</Button>
+					</div>
+				</form>
+			</div>
+		</>
+	);
+}

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -163,8 +163,8 @@ export function TaskList({
 
 									<div className='mt-2 space-y-2'>
 										<p className='text-xs text-muted-foreground'>
-											{task.timerStartedAt ? 'Running now' : 'Stopped'} �
-											Today: {getTaskTodayLabel(task)} � Total:{' '}
+											{task.timerStartedAt ? 'Running now' : 'Stopped'} {' · '}
+											Today: {getTaskTodayLabel(task)} {' · '} Total:{' '}
 											{getTaskTotalLabel(task)}
 										</p>
 										<form

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -29,6 +29,7 @@ import {
 type TaskTrackingAction = (formData: FormData) => Promise<void>;
 
 type TaskListProps = {
+	openQuickAddHref: string;
 	selectedTaskId: number | null;
 	startTrackingAction: TaskTrackingAction;
 	stopTrackingAction: TaskTrackingAction;
@@ -37,6 +38,7 @@ type TaskListProps = {
 };
 
 export function TaskList({
+	openQuickAddHref,
 	selectedTaskId,
 	startTrackingAction,
 	stopTrackingAction,
@@ -44,7 +46,7 @@ export function TaskList({
 	tasks
 }: TaskListProps) {
 	return (
-		<Card className='min-h-[420px]'>
+		<Card className='flex min-h-[520px] lg:h-[calc(100vh-4rem)] flex-col'>
 			<CardHeader className='border-b border-border'>
 				<CardTitle className='text-base tracking-tight'>Task list</CardTitle>
 				<CardDescription>
@@ -52,7 +54,7 @@ export function TaskList({
 					current search and filters.
 				</CardDescription>
 			</CardHeader>
-			<CardContent>
+			<CardContent className='min-h-0 flex-1 overflow-y-auto'>
 				{tasks.length === 0 ?
 					<Empty className='border border-dashed border-border bg-muted/20'>
 						<EmptyHeader>
@@ -72,7 +74,7 @@ export function TaskList({
 								asChild
 								type='button'
 								variant='secondary'>
-								<a href='#quick-add'>
+								<a href={openQuickAddHref}>
 									<Plus
 										aria-hidden='true'
 										className='size-4'

--- a/src/components/url-dialog.tsx
+++ b/src/components/url-dialog.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+type UrlDialogProps = {
+	children: ReactNode;
+	closeHref: string;
+	contentClassName?: string;
+	contentId?: string;
+	open: boolean;
+};
+
+export function UrlDialog({
+	children,
+	closeHref,
+	contentClassName,
+	contentId,
+	open
+}: UrlDialogProps) {
+	const router = useRouter();
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					router.push(closeHref);
+				}
+			}}>
+			<DialogContent
+				id={contentId}
+				className={contentClassName}>
+				{children}
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Closes #50

## Scope
- Move Quick Add and Task Detail out of the always-visible right column into focused shadcn/ui dialogs.
- Rebalance the main page so overview controls stay left and the Task List owns the right column.
- Update focused Playwright coverage for create, detail open/close, edit persistence, and detail link/session flows.

## Changed layout behavior
- Left column keeps Local Task Hub/search/actions, today worked summary, filters, and Recently opened.
- Right column now contains the Task List in a bounded internal scroll area.

## Dialog behavior
- Create task opens Quick Add via the existing Create task entry point and closes back to the current search/filter state after submit.
- Clicking a task title opens Task Detail in a centered dialog via taskId.
- Closing Task Detail removes taskId while preserving search/filter params.
- Long Quick Add and Task Detail content scrolls inside the dialog.

## Files changed
- src/app/page.tsx
- src/components/task-list.tsx
- src/components/url-dialog.tsx
- src/components/quick-add-dialog-content.tsx
- src/components/task-detail-dialog-content.tsx
- e2e/create-task.spec.ts
- e2e/task-detail-links.spec.ts
- e2e/time-tracking.spec.ts
- e2e/search-filtering.spec.ts
- e2e/export.spec.ts
- e2e/task-complete-reopen.spec.ts

## Validation performed
- npm run lint: passed
- npm run build: passed
- npx playwright test e2e/create-task.spec.ts --project=chromium --reporter=line: 4 passed
- npx playwright test e2e/task-detail-links.spec.ts --project=chromium --reporter=line: 2 passed

## Playwright tests added/updated
- Added Task Detail close URL coverage in create-task.spec.ts.
- Updated create/detail/link/session specs to open Quick Add and Task Detail through dialogs.
- Updated related specs that create tasks to use the Quick Add dialog flow.

## Tests skipped
- Full Playwright suite was not run; this issue only changed focused create/detail layout flows and the requested focused Chromium specs passed.

## Time Session UX
- Time Session ISO inputs, duration seconds input behavior, parsing semantics, and add-session behavior were intentionally left unchanged.