### PR TITLE
Docs: add local E2E task cleanup workflow

### DIFF
--- a/docs/local-mysql.md
+++ b/docs/local-mysql.md
@@ -60,6 +60,46 @@ MySQL data is persisted in the named Docker volume declared in `docker-compose.y
 
 That means data survives container restarts and `docker compose down`.
 
+## Clean up local E2E-created tasks
+
+Use this only for a local development database when repeated Playwright runs have
+created many test tasks. The current E2E specs use task titles that start with an
+issue-style prefix such as `Issue2`, `Issue10`, or `Issue36`; this workflow only
+targets titles matching `^Issue[0-9]+` by default.
+
+Preview the matching records before deleting anything:
+
+```bash
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT COUNT(*) AS issue_test_tasks FROM tasks WHERE title REGEXP '^Issue[0-9]+';"
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT id, title, status, created_at, updated_at FROM tasks WHERE title REGEXP '^Issue[0-9]+' ORDER BY created_at DESC LIMIT 50;"
+```
+
+Check what would be preserved:
+
+```bash
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT COUNT(*) AS non_issue_tasks FROM tasks WHERE title NOT REGEXP '^Issue[0-9]+';"
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT id, title, status, created_at, updated_at FROM tasks WHERE title NOT REGEXP '^Issue[0-9]+' ORDER BY created_at DESC;"
+```
+
+Delete only after the preview confirms that the matching rows are disposable
+local E2E artifacts:
+
+```bash
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "DELETE FROM tasks WHERE title REGEXP '^Issue[0-9]+';"
+```
+
+Verify the remaining task count:
+
+```bash
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT COUNT(*) AS remaining_tasks FROM tasks;"
+```
+
+Related rows in `task_links`, `task_tags`, `task_person_references`,
+`task_time_sessions`, and `task_recent_opens` are removed by the schema's
+existing `ON DELETE CASCADE` foreign keys when the parent `tasks` rows are
+deleted. Do not broaden the `WHERE` clause unless you intentionally want to
+delete manual local tasks too.
+
 ## Application DB module behavior (server-side)
 
 The application uses a dedicated server-side module at `src/lib/server/db.ts`.


### PR DESCRIPTION
## Scope
Closes #54

## Files changed
- docs/local-mysql.md

## Changes
- Documents a preview-first cleanup workflow for local E2E-created tasks using the existing Issue-prefixed title pattern.
- Adds delete and verification commands scoped to matching local test tasks.
- Notes that related rows are removed by existing ON DELETE CASCADE constraints.

## Validation
- git status --short -> showed only docs/local-mysql.md before commit
- git diff -- docs README.md package.json -> reviewed docs-only diff before commit
- git diff --check -> passed; Git reported the existing Windows LF/CRLF warning for docs/local-mysql.md

## Follow-up
- None