### PR TITLE
Improve time session editing UX

### DIFF
--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -109,12 +109,11 @@ test('task detail supports structured time session editing and explicit removal'
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
 
-  const startedAt = '2026-01-02T03:04:05.000Z'
-  const endedAt = '2026-01-02T04:04:05.000Z'
+  const startedAt = '2026-01-02T03:04:05'
+  const endedAt = '2026-01-02T04:04:05'
 
   await page.locator('#detailTimeSessionStartedAt-0').fill(startedAt)
   await page.locator('#detailTimeSessionEndedAt-0').fill(endedAt)
-  await page.locator('#detailTimeSessionDuration-0').fill('3600')
 
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
@@ -128,7 +127,7 @@ test('task detail supports structured time session editing and explicit removal'
 
   await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(startedAt)
   await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(endedAt)
-  await expect(page.locator('#detailTimeSessionDuration-0')).toHaveValue('3600')
+  await expect(page.getByTestId('time-session-duration')).toHaveText('1h 0m')
 
   await page.locator('#detailTimeSessionRemove-0').check()
 

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -5,6 +5,17 @@ function buildUnique(testName: string) {
   return `${testName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+function formatDateTimeLocalValue(value: Date) {
+  const year = value.getFullYear()
+  const month = String(value.getMonth() + 1).padStart(2, "0")
+  const day = String(value.getDate()).padStart(2, "0")
+  const hours = String(value.getHours()).padStart(2, "0")
+  const minutes = String(value.getMinutes()).padStart(2, "0")
+  const seconds = String(value.getSeconds()).padStart(2, "0")
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`
+}
+
 async function withDbConnection() {
   return mysql.createConnection({
     host: process.env.DB_HOST ?? process.env.MYSQL_HOST ?? "127.0.0.1",
@@ -117,9 +128,9 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
   const startedAt = new Date(startedAtRaw)
   const correctedEndedAt = new Date(startedAt.getTime() + 2 * 60 * 1000)
+  const correctedEndedAtInput = formatDateTimeLocalValue(correctedEndedAt)
 
-  await page.locator("#detailTimeSessionEndedAt-0").fill(correctedEndedAt.toISOString())
-  await page.locator("#detailTimeSessionDuration-0").fill("")
+  await page.locator("#detailTimeSessionEndedAt-0").fill(correctedEndedAtInput)
   await saveTaskDetail(page)
 
   await showOnlyTask(page, title)
@@ -133,7 +144,8 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
 
   await openTaskDetail(page, title)
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
-  await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(correctedEndedAt.toISOString())
+  await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(correctedEndedAtInput)
+  await expect(page.getByTestId("time-session-duration")).toHaveText("2m")
 
   await expect(page.getByText("Today total tracked:")).toBeVisible()
 })
@@ -162,7 +174,7 @@ test("double start submission does not create duplicate running sessions", async
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
   await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue("")
-  await expect(page.locator("#detailTimeSessionDuration-0")).toHaveValue("")
+  await expect(page.getByTestId("time-session-duration")).toHaveText("Running")
 })
 
 test("double stop submission does not mutate ended session twice", async ({ page }, testInfo) => {
@@ -195,17 +207,16 @@ test("double stop submission does not mutate ended session twice", async ({ page
 
   const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
   const endedAtRaw = await page.locator("#detailTimeSessionEndedAt-0").inputValue()
-  const durationRaw = await page.locator("#detailTimeSessionDuration-0").inputValue()
 
   expect(endedAtRaw).not.toBe("")
-  expect(durationRaw).toMatch(/^\d+$/)
 
   const startedAt = new Date(startedAtRaw)
   const endedAt = new Date(endedAtRaw)
-  const durationSeconds = Number.parseInt(durationRaw, 10)
 
   const expectedSeconds = Math.max(0, Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000))
-  expect(durationSeconds).toBe(expectedSeconds)
+  await expect(page.getByTestId("time-session-duration")).toHaveText(
+    expectedSeconds >= 60 ? /\d+m/ : "0m"
+  )
 })
 
 test("today totals include overlap for sessions that started before midnight", async ({ page }, testInfo) => {
@@ -260,9 +271,9 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
   const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
   const startedAt = new Date(startedAtRaw)
   const editedEndedAt = new Date(startedAt.getTime() + 10 * 60 * 1000)
+  const editedEndedAtInput = formatDateTimeLocalValue(editedEndedAt)
 
-  await page.locator("#detailTimeSessionEndedAt-0").fill(editedEndedAt.toISOString())
-  await page.locator("#detailTimeSessionDuration-0").fill("1")
+  await page.locator("#detailTimeSessionEndedAt-0").fill(editedEndedAtInput)
   await saveTaskDetail(page)
 
   await showOnlyTask(page, title)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,7 +136,6 @@ function parseTimeSessionsInput(formData: FormData) {
 	const sessions: Array<{
 		startedAt: Date;
 		endedAt: Date | null;
-		durationSeconds: number | null;
 	}> = [];
 
 	for (let index = 0; index < count; index += 1) {
@@ -168,31 +167,9 @@ function parseTimeSessionsInput(formData: FormData) {
 			throw new Error(`Invalid ended_at value in time sessions: ${endedAtRaw}`);
 		}
 
-		const durationRaw = String(
-			formData.get('detailTimeSessionDuration_' + index) ?? ''
-		).trim();
-		const durationSeconds =
-			durationRaw ? Number.parseInt(durationRaw, 10) : null;
-
-		if (durationRaw && Number.isNaN(durationSeconds)) {
-			throw new Error(
-				`Invalid duration_seconds value in time sessions: ${durationRaw}`
-			);
-		}
-
-		const normalizedDurationSeconds =
-			endedAt ?
-				(durationSeconds ??
-				Math.max(
-					0,
-					Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000)
-				))
-			:	durationSeconds;
-
 		sessions.push({
 			startedAt,
-			endedAt,
-			durationSeconds: normalizedDurationSeconds
+			endedAt
 		});
 	}
 

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { formatDuration } from '@/components/task-display-helpers';
 
 type UpdateTaskDetailAction = (
 	taskId: number,
@@ -31,6 +32,33 @@ function formatTimestamp(value: Date) {
 		dateStyle: 'medium',
 		timeStyle: 'short'
 	}).format(value);
+}
+
+function formatDateTimeLocalValue(value: Date) {
+	const year = value.getFullYear();
+	const month = String(value.getMonth() + 1).padStart(2, '0');
+	const day = String(value.getDate()).padStart(2, '0');
+	const hours = String(value.getHours()).padStart(2, '0');
+	const minutes = String(value.getMinutes()).padStart(2, '0');
+	const seconds = String(value.getSeconds()).padStart(2, '0');
+
+	return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+}
+
+function getTimeSessionDurationLabel(
+	startedAt: Date,
+	endedAt: Date | null
+) {
+	if (!endedAt) {
+		return 'Running';
+	}
+
+	const derivedSeconds = Math.max(
+		0,
+		Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000)
+	);
+
+	return formatDuration(derivedSeconds);
 }
 
 function getLinkDomainHint(url: string) {
@@ -213,7 +241,7 @@ export function TaskDetailDialogContent({
 						<div className='space-y-1.5'>
 							<p className='text-sm font-medium'>Time sessions</p>
 							<p className='text-xs text-muted-foreground'>
-								Edit each session directly using ISO date-time values.
+								Edit start and end times with local date and time fields.
 							</p>
 						</div>
 						<input
@@ -240,7 +268,9 @@ export function TaskDetailDialogContent({
 												<Input
 													id={'detailTimeSessionStartedAt-' + index}
 													name={'detailTimeSessionStartedAt_' + index}
-													defaultValue={session.startedAt.toISOString()}
+													type='datetime-local'
+													step='1'
+													defaultValue={formatDateTimeLocalValue(session.startedAt)}
 													className='font-mono text-xs'
 													required
 												/>
@@ -254,25 +284,28 @@ export function TaskDetailDialogContent({
 												<Input
 													id={'detailTimeSessionEndedAt-' + index}
 													name={'detailTimeSessionEndedAt_' + index}
+													type='datetime-local'
+													step='1'
 													defaultValue={
-														session.endedAt ? session.endedAt.toISOString() : ''
+														session.endedAt ?
+															formatDateTimeLocalValue(session.endedAt)
+														:	''
 													}
 													className='font-mono text-xs'
 												/>
 											</div>
 											<div className='space-y-1'>
-												<label
-													htmlFor={'detailTimeSessionDuration-' + index}
-													className='text-xs font-medium text-muted-foreground'>
-													Duration (seconds)
-												</label>
-												<Input
-													id={'detailTimeSessionDuration-' + index}
-													name={'detailTimeSessionDuration_' + index}
-													defaultValue={session.durationSeconds ?? ''}
-													className='font-mono text-xs'
-													inputMode='numeric'
-												/>
+												<p className='text-xs font-medium text-muted-foreground'>
+													Duration
+												</p>
+												<p
+													className='rounded-md border border-border bg-background px-3 py-2 text-sm'
+													data-testid='time-session-duration'>
+													{getTimeSessionDurationLabel(
+														session.startedAt,
+														session.endedAt
+													)}
+												</p>
 											</div>
 										</div>
 										<div className='mt-2'>

--- a/src/lib/server/tasks.ts
+++ b/src/lib/server/tasks.ts
@@ -159,7 +159,6 @@ export type UpdateTaskDetailInput = {
   timeSessions?: Array<{
     startedAt: Date
     endedAt: Date | null
-    durationSeconds: number | null
   }>
 }
 
@@ -886,4 +885,4 @@ export async function updateTaskDetail(input: UpdateTaskDetailInput) {
     connection.release()
   }
 }
-
+


### PR DESCRIPTION
## Scope
- Replaces raw ISO time-session editing with `datetime-local` inputs in Task Detail.
- Removes editable duration seconds from the form and shows a derived readable duration instead.
- Updates focused Playwright coverage for local date/time editing, running sessions, duration display, and removal.

## Validation
- `npm run lint` passed.
- `npm run build` passed.
- `git diff --check` passed with existing Windows line-ending warnings only.
- `npx playwright test e2e/time-tracking.spec.ts e2e/task-detail-links.spec.ts --project=chromium` passed: 7/7.
- Manual Playwright UI smoke passed against `http://127.0.0.1:3000`.

Closes #52