### PR TITLE
Show multiple source badges in task list

### DIFF
--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -35,7 +35,14 @@ test('task detail renders attached links as clickable items and keeps one-per-li
 
   await page
     .locator('#detailLinks')
-    .fill('https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab')
+    .fill(
+      [
+        'https://github.com/vercel/next.js',
+        'https://gitlab.com/gitlab-org/gitlab',
+        'https://localtaskhub.atlassian.net/browse/LTH-38',
+        'https://example.com/task-38',
+      ].join('\n'),
+    )
 
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
@@ -66,10 +73,22 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await popup.close()
 
   await showOnlyTask(page, title)
+  const taskCard = page.getByTestId('main-task-list').locator('li', { hasText: title })
+  await expect(taskCard).toContainText('GitHub')
+  await expect(taskCard).toContainText('GitLab')
+  await expect(taskCard).toContainText('Jira')
+  await expect(taskCard).toContainText('+1')
+
+  await showOnlyTask(page, title)
   await openTaskDetail(page, title)
 
   await expect(page.locator('#detailLinks')).toHaveValue(
-    'https://github.com/vercel/next.js\nhttps://gitlab.com/gitlab-org/gitlab',
+    [
+      'https://github.com/vercel/next.js',
+      'https://gitlab.com/gitlab-org/gitlab',
+      'https://localtaskhub.atlassian.net/browse/LTH-38',
+      'https://example.com/task-38',
+    ].join('\n'),
   )
   await expect(page.getByLabel('Attached links')).toBeVisible()
 })

--- a/src/components/task-display-helpers.ts
+++ b/src/components/task-display-helpers.ts
@@ -47,6 +47,36 @@ export function getSourceBadgeLabel(task: Task) {
 	return SOURCE_LABELS[task.firstLinkSourceType];
 }
 
+export function getSourceBadgeItems(task: Task, visibleLimit = 3) {
+	const sourceTypes =
+		task.sourceTypes.length > 0 ?
+			task.sourceTypes
+		: task.firstLinkSourceType ?
+			[task.firstLinkSourceType]
+		:	[];
+
+	if (!task.firstLink || sourceTypes.length === 0) {
+		return [{ key: 'local', label: 'Local' }];
+	}
+
+	const boundedVisibleLimit = Math.max(1, visibleLimit);
+	const visibleSourceTypes = sourceTypes.slice(0, boundedVisibleLimit);
+	const hiddenCount = sourceTypes.length - visibleSourceTypes.length;
+	const items: Array<{ key: string; label: string }> = visibleSourceTypes.map((sourceType) => ({
+		key: sourceType,
+		label: SOURCE_LABELS[sourceType]
+	}));
+
+	if (hiddenCount > 0) {
+		items.push({
+			key: 'overflow',
+			label: `+${hiddenCount}`
+		});
+	}
+
+	return items;
+}
+
 export function getTaskTodayLabel(task: Task) {
 	return task.todayTrackedSeconds > 0 ?
 			formatDuration(task.todayTrackedSeconds)

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -3,7 +3,7 @@ import { Play, Plus, Search, Square } from 'lucide-react';
 
 import type { Task } from '@/lib/server/tasks';
 import {
-	getSourceBadgeLabel,
+	getSourceBadgeItems,
 	getTaskTodayLabel,
 	getTaskTotalLabel,
 	truncateNote
@@ -93,6 +93,7 @@ export function TaskList({
 							const taskHrefParams = new URLSearchParams(taskLinkParams);
 							taskHrefParams.set('taskId', String(task.id));
 							const taskHref = `/?${taskHrefParams.toString()}#task-detail`;
+							const sourceBadgeItems = getSourceBadgeItems(task);
 
 							return (
 								<li
@@ -119,11 +120,14 @@ export function TaskList({
 												className='text-xs'>
 												{task.status}
 											</Badge>
-											<Badge
-												variant='secondary'
-												className='text-xs'>
-												{getSourceBadgeLabel(task)}
-											</Badge>
+											{sourceBadgeItems.map((sourceBadgeItem) => (
+												<Badge
+													key={`${task.id}-source-${sourceBadgeItem.key}`}
+													variant='secondary'
+													className='text-xs'>
+													{sourceBadgeItem.label}
+												</Badge>
+											))}
 										</div>
 									</div>
 

--- a/src/lib/server/tasks.ts
+++ b/src/lib/server/tasks.ts
@@ -36,6 +36,7 @@ type TaskRow = RowDataPacket & {
   note: string | null
   first_link: string | null
   first_link_source_type: TaskSourceType | null
+  link_sources_serialized: string | null
   tags_serialized: string | null
   people_serialized: string | null
   timer_started_at: Date | null
@@ -93,6 +94,7 @@ export type Task = {
   note: string | null
   firstLink: string | null
   firstLinkSourceType: TaskSourceType | null
+  sourceTypes: TaskSourceType[]
   tags: string[]
   people: string[]
   timerStartedAt: Date | null
@@ -185,6 +187,18 @@ function normalizeList(values?: string[]) {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))]
 }
 
+function dedupeSourceTypes(values: string[]) {
+  return values.filter(
+    (value, index): value is TaskSourceType =>
+      (value === "jira" ||
+        value === "gitlab" ||
+        value === "github" ||
+        value === "confluence" ||
+        value === "other") &&
+      values.indexOf(value) === index,
+  )
+}
+
 function inferSourceTypeFromUrl(url: string | null): TaskSourceType {
   if (!url) {
     return "other"
@@ -224,6 +238,7 @@ function mapRow(row: TaskRow): Task {
     note: row.note,
     firstLink: row.first_link,
     firstLinkSourceType: row.first_link_source_type ?? inferSourceTypeFromUrl(row.first_link),
+    sourceTypes: dedupeSourceTypes(parseSerializedList(row.link_sources_serialized)),
     tags: parseSerializedList(row.tags_serialized),
     people: parseSerializedList(row.people_serialized),
     timerStartedAt: row.timer_started_at,
@@ -308,7 +323,11 @@ export async function listRecentlyOpenedTasks(limit = MAX_RECENTLY_OPENED_TASKS)
 
 export async function listTasks(filters: TaskListFilters = {}) {
   const whereClauses: string[] = []
-  const params: Array<string | number | boolean | Date | null> = [LIST_SEPARATOR, LIST_SEPARATOR]
+  const params: Array<string | number | boolean | Date | null> = [
+    LIST_SEPARATOR,
+    LIST_SEPARATOR,
+    LIST_SEPARATOR,
+  ]
 
   const query = filters.query?.trim()
   if (query) {
@@ -467,6 +486,22 @@ export async function listTasks(filters: TaskListFilters = {}) {
           ORDER BY tl.created_at ASC, tl.id ASC
           LIMIT 1
         ) AS first_link_source_type,
+        (
+          SELECT GROUP_CONCAT(
+            CASE
+              WHEN LOWER(tl.url) LIKE '%atlassian.net%' OR LOWER(tl.url) LIKE '%jira%' THEN 'jira'
+              WHEN LOWER(tl.url) LIKE '%gitlab%' THEN 'gitlab'
+              WHEN LOWER(tl.url) LIKE '%github%' THEN 'github'
+              WHEN LOWER(tl.url) LIKE '%confluence%' THEN 'confluence'
+              WHEN tl.source_type IN ('jira', 'gitlab', 'github', 'confluence') THEN tl.source_type
+              ELSE 'other'
+            END
+            ORDER BY tl.created_at ASC, tl.id ASC
+            SEPARATOR ?
+          )
+          FROM task_links tl
+          WHERE tl.task_id = t.id
+        ) AS link_sources_serialized,
         (
           SELECT GROUP_CONCAT(tt.tag ORDER BY tt.tag SEPARATOR ?)
           FROM task_tags tt


### PR DESCRIPTION
## Scope
Closes #38

## Changes
- Add all task-link source types to the task list data returned by the server.
- Render compact source badges on task cards with a three-badge visible limit and +N overflow.
- Extend link-detail Playwright coverage to verify multiple task-list source badges and overflow.

## Validation
- npm run lint
- npm run build
- npx playwright test e2e/task-detail-links.spec.ts --project=chromium --reporter=line

## Follow-up
- None