### PR TITLE
[codex] Stabilize Playwright CI browser setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     services:
       mysql:
         image: mysql:8.4
@@ -28,7 +30,7 @@ jobs:
           --health-timeout=5s
           --health-retries=10
     env:
-      DB_HOST: 127.0.0.1
+      DB_HOST: mysql
       DB_PORT: 3306
       DB_USER: root
       DB_PASSWORD: localtaskhub
@@ -41,31 +43,10 @@ jobs:
         cache: npm
     - name: Install dependencies
       run: npm ci
-    - name: Resolve Playwright version
-      id: playwright-version
-      run: |
-        PLAYWRIGHT_VERSION=$(node -p "require('@playwright/test/package.json').version")
-        echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
-    - name: Cache Playwright browsers
-      id: playwright-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
     - name: Wait for MySQL service
-      run: |
-        for i in {1..30}; do
-          if mysqladmin ping -h 127.0.0.1 -uroot -plocaltaskhub --silent; then
-            exit 0
-          fi
-          sleep 2
-        done
-        echo "MySQL did not become ready in time"
-        exit 1
+      run: node .github/workflows/scripts/wait-for-mysql.mjs
     - name: Apply DB schema
-      run: mysql -h 127.0.0.1 -uroot -plocaltaskhub local-task-hub < .docker/db_schema.sql
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps chromium
+      run: node .github/workflows/scripts/apply-db-schema.mjs
     - name: Run Playwright tests
       run: npx playwright test --project=chromium
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,9 @@ jobs:
       run: npm ci
     - name: Resolve Playwright version
       id: playwright-version
-      run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+      run: |
+        PLAYWRIGHT_VERSION=$(node -p "require('@playwright/test/package.json').version")
+        echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,8 +2,14 @@ name: Playwright Tests
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 jobs:
   test:
     timeout-minutes: 60
@@ -32,8 +38,18 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+        cache: npm
     - name: Install dependencies
       run: npm ci
+    - name: Resolve Playwright version
+      id: playwright-version
+      run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
     - name: Wait for MySQL service
       run: |
         for i in {1..30}; do
@@ -47,7 +63,7 @@ jobs:
     - name: Apply DB schema
       run: mysql -h 127.0.0.1 -uroot -plocaltaskhub local-task-hub < .docker/db_schema.sql
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps chromium
     - name: Run Playwright tests
       run: npx playwright test --project=chromium
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/scripts/apply-db-schema.mjs
+++ b/.github/workflows/scripts/apply-db-schema.mjs
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+
+import mysql from "mysql2/promise";
+
+const schema = await readFile(".docker/db_schema.sql", "utf8");
+
+const connection = await mysql.createConnection({
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT ?? 3306),
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  multipleStatements: true,
+});
+
+try {
+  await connection.query(schema);
+} finally {
+  await connection.end();
+}

--- a/.github/workflows/scripts/wait-for-mysql.mjs
+++ b/.github/workflows/scripts/wait-for-mysql.mjs
@@ -1,0 +1,27 @@
+import mysql from "mysql2/promise";
+
+const config = {
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT ?? 3306),
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+};
+
+const maxAttempts = 30;
+
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  try {
+    const connection = await mysql.createConnection(config);
+    await connection.ping();
+    await connection.end();
+    process.exit(0);
+  } catch (error) {
+    if (attempt === maxAttempts) {
+      console.error("MySQL did not become ready in time.");
+      console.error(error);
+      process.exit(1);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+}


### PR DESCRIPTION
## Scope
Closes #62.

## Changes
- Skip the Playwright workflow for docs-only Markdown changes via `paths-ignore`.
- Enable npm dependency caching in `actions/setup-node`.
- Run the Playwright job inside the official `mcr.microsoft.com/playwright:v1.58.2-noble` image so Chromium and system browser dependencies are already present.
- Remove the explicit `npx playwright install --with-deps` browser install step from CI.
- Replace MySQL CLI usage with small `mysql2` Node scripts so the containerized job can wait for MySQL and apply the schema without installing extra CLI packages.

## CI behavior
- Docs-only Markdown or `docs/**` PRs skip this Playwright workflow intentionally.
- Source, test, package, config, and workflow changes still trigger Playwright.
- Browser installation is skipped because the Playwright browser binaries and dependencies come from the pinned Playwright CI image.
- Tests still run with the existing CI target: `npx playwright test --project=chromium`.

## Validation
- `node --check .github/workflows/scripts/wait-for-mysql.mjs` passed locally.
- `node --check .github/workflows/scripts/apply-db-schema.mjs` passed locally.
- `npm run lint` passed locally.
- `npm run build` passed locally.
- `git diff --check` passed locally; PowerShell reported only the repository's Windows line-ending warning for edited workflow files.
- GitHub Actions `Playwright Tests / test` passed on this PR in 3m04s: https://github.com/daviddomain/local-task-hub/actions/runs/27010061246

## Follow-up
- If `@playwright/test` is upgraded, update the pinned Playwright CI image tag to the matching Playwright version.
