### PR TITLE
Document local MySQL backup and restore workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ http://localhost:3000
 
 MySQL runs through Docker Compose and stores data in the named Docker volume declared in `docker-compose.yml`, so local data survives container restarts and `docker compose down`.
 
-For health checks, persistence details, and safe reset steps, see [docs/local-mysql.md](docs/local-mysql.md).
+For health checks, persistence details, backup/restore, and safe reset steps, see [docs/local-mysql.md](docs/local-mysql.md).
 
 ## Validation
 
@@ -73,7 +73,7 @@ CI currently runs the Chromium Playwright project against a MySQL service.
 
 - [MVP.md](MVP.md) is the product source of truth for Phase 1.
 - [AGENTS.md](AGENTS.md) contains Codex and project-agent guidance.
-- [docs/local-mysql.md](docs/local-mysql.md) documents the local MySQL setup.
+- [docs/local-mysql.md](docs/local-mysql.md) documents the local MySQL setup, including backup and restore.
 
 ## Exports And Local Data
 

--- a/docs/local-mysql.md
+++ b/docs/local-mysql.md
@@ -60,6 +60,61 @@ MySQL data is persisted in the named Docker volume declared in `docker-compose.y
 
 That means data survives container restarts and `docker compose down`.
 
+## Backup and restore local app data
+
+Use this workflow for a local development backup before risky experiments,
+manual cleanup, or moving data between local project checkouts. The commands are
+project-specific for the Docker Compose service `db`, database
+`local-task-hub`, and local root password `localtaskhub`.
+
+Create a backup directory outside the repository so SQL dumps are not committed
+accidentally:
+
+```powershell
+$backupDir = "$env:USERPROFILE\local-task-hub-backups"
+New-Item -ItemType Directory -Force -Path $backupDir
+```
+
+Create a `mysqldump` backup:
+
+```powershell
+$backupPath = "$backupDir\local-task-hub-$(Get-Date -Format 'yyyyMMdd-HHmmss').sql"
+docker compose exec -T db mysqldump -uroot -plocaltaskhub local-task-hub > $backupPath
+```
+
+Verify that the backup file exists and is not empty before relying on it:
+
+```powershell
+Get-Item $backupPath | Select-Object FullName, Length, LastWriteTime
+```
+
+For a later restore, set `$backupPath` to the exact file you want to restore:
+
+```powershell
+$backupPath = "$env:USERPROFILE\local-task-hub-backups\local-task-hub-YYYYMMDD-HHMMSS.sql"
+Test-Path $backupPath
+```
+
+Only restore after `Test-Path` returns `True`.
+
+Warning: restoring a dump can overwrite local project data in the
+`local-task-hub` database. Review the selected backup file and stop any running
+`npm run dev` process before restore if you want to avoid writes while
+importing.
+
+Restore the backup into the local project database:
+
+```powershell
+Get-Content -Raw $backupPath | docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub
+```
+
+Confirm the database is still reachable after restore:
+
+```powershell
+docker compose exec -T db mysqladmin -uroot -plocaltaskhub ping
+docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub -e "SELECT COUNT(*) AS tasks FROM tasks;"
+```
+
 ## Clean up local E2E-created tasks
 
 Use this only for a local development database when repeated Playwright runs have

--- a/docs/local-mysql.md
+++ b/docs/local-mysql.md
@@ -79,13 +79,18 @@ Create a `mysqldump` backup:
 
 ```powershell
 $backupPath = "$backupDir\local-task-hub-$(Get-Date -Format 'yyyyMMdd-HHmmss').sql"
-docker compose exec -T db mysqldump -uroot -plocaltaskhub local-task-hub > $backupPath
+docker compose exec -T db sh -c "mysqldump -uroot -plocaltaskhub local-task-hub > /tmp/local-task-hub-backup.sql"
+docker compose cp db:/tmp/local-task-hub-backup.sql $backupPath
+docker compose exec -T db rm /tmp/local-task-hub-backup.sql
 ```
 
 Verify that the backup file exists and is not empty before relying on it:
 
 ```powershell
-Get-Item $backupPath | Select-Object FullName, Length, LastWriteTime
+$backup = Get-Item $backupPath
+$backup.FullName
+$backup.Length
+$backup.LastWriteTime
 ```
 
 For a later restore, set `$backupPath` to the exact file you want to restore:
@@ -105,7 +110,9 @@ importing.
 Restore the backup into the local project database:
 
 ```powershell
-Get-Content -Raw $backupPath | docker compose exec -T db mysql -uroot -plocaltaskhub local-task-hub
+docker compose cp $backupPath db:/tmp/local-task-hub-restore.sql
+docker compose exec -T db sh -c "mysql -uroot -plocaltaskhub local-task-hub < /tmp/local-task-hub-restore.sql"
+docker compose exec -T db rm /tmp/local-task-hub-restore.sql
 ```
 
 Confirm the database is still reachable after restore:


### PR DESCRIPTION
## Scope

Closes #64.

## Changes

- Document where local MySQL data persists through the Docker volume.
- Add `mysqldump` backup and restore commands using temporary files inside the `db` container plus `docker compose cp`.
- Add restore safety notes and README discoverability for the backup/restore docs.

## Validation

- Reviewed the Markdown diff.
- Ran `git diff --check` successfully. Git only reported Windows line-ending warnings for the touched Markdown files.

## Notes

- Documentation-only change.
- No product code, schema, dependencies, or Playwright coverage changed.