### PR TITLE
Replace task detail Later checkbox with toggle

### DIFF
--- a/e2e/task-complete-reopen.spec.ts
+++ b/e2e/task-complete-reopen.spec.ts
@@ -43,18 +43,20 @@ test("mark task done and reopen persists status while preserving later flag", as
 
   await openTaskDetail(page, title)
 
-  await page.locator("#detailLater").focus()
+  const laterToggle = page.getByRole("button", { name: "Later" })
+
+  await laterToggle.focus()
   await page.keyboard.press("Space")
 
   await page.getByRole("button", { name: "Save detail" }).click()
-  await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
+  await expect(laterToggle).toHaveAttribute("aria-pressed", /^(true|1)$/)
   await closeTaskDetail(page)
 
   await showOnlyTask(page, title)
   await expect(card).toContainText("later")
   await openTaskDetail(page, title)
   await expect(page.locator("#detailStatus")).toContainText("open")
-  await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
+  await expect(page.getByRole("button", { name: "Later" })).toHaveAttribute("aria-pressed", /^(true|1)$/)
 
   await page.getByRole("button", { name: "Mark done" }).click()
   await expect(page.getByRole("button", { name: "Reopen task" })).toBeVisible()
@@ -84,7 +86,7 @@ test("mark task done and reopen persists status while preserving later flag", as
   await expect(card).toContainText("later")
   await openTaskDetail(page, title)
   await expect(page.locator("#detailStatus")).toContainText("open")
-  await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
+  await expect(page.getByRole("button", { name: "Later" })).toHaveAttribute("aria-pressed", /^(true|1)$/)
 
   await page.reload({ waitUntil: "domcontentloaded" })
   await expect(page.locator("#detailTitle")).toHaveValue(title)
@@ -94,6 +96,16 @@ test("mark task done and reopen persists status while preserving later flag", as
   await expect(persistedCard).toContainText("open")
   await expect(persistedCard).toContainText("later")
   await expect(page.locator("#detailStatus")).toContainText("open")
-  await expect(page.getByRole("checkbox", { name: "Later" })).toHaveAttribute("aria-checked", /^(true|1)$/)
+  await expect(page.getByRole("button", { name: "Later" })).toHaveAttribute("aria-pressed", /^(true|1)$/)
+
+  await page.getByRole("button", { name: "Later" }).click()
+  await page.getByRole("button", { name: "Save detail" }).click()
+  await expect(page.getByRole("button", { name: "Later" })).toHaveAttribute("aria-pressed", /^(false|0)$/)
+  await closeTaskDetail(page)
+
+  await showOnlyTask(page, title)
+  await expect(persistedCard).not.toContainText("later")
+  await openTaskDetail(page, title)
+  await expect(page.getByRole("button", { name: "Later" })).toHaveAttribute("aria-pressed", /^(false|0)$/)
 })
 

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link';
 import { Download } from 'lucide-react';
 
 import type { TaskDetail } from '@/lib/server/tasks';
+import { TaskDetailLaterToggle } from '@/components/task-detail-later-toggle';
 import { SelectFormField } from '@/components/select-form-field';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
 	DialogDescription,
 	DialogHeader,
@@ -135,16 +135,7 @@ export function TaskDetailDialogContent({
 							/>
 						</div>
 
-						<div className='flex items-end'>
-							<label className='flex items-center gap-2 text-sm'>
-								<Checkbox
-									id='detailLater'
-									name='detailLater'
-									defaultChecked={selectedTask.later}
-								/>
-								Later
-							</label>
-						</div>
+						<TaskDetailLaterToggle defaultPressed={selectedTask.later} />
 					</div>
 
 					<div>

--- a/src/components/task-detail-later-toggle.tsx
+++ b/src/components/task-detail-later-toggle.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import * as React from 'react';
+
+import { Toggle } from '@/components/ui/toggle';
+
+type TaskDetailLaterToggleProps = {
+	defaultPressed: boolean;
+};
+
+export function TaskDetailLaterToggle({
+	defaultPressed
+}: TaskDetailLaterToggleProps) {
+	const [pressed, setPressed] = React.useState(defaultPressed);
+
+	return (
+		<div className='flex items-end'>
+			<input
+				type='hidden'
+				name={pressed ? 'detailLater' : undefined}
+				value='on'
+			/>
+			<Toggle
+				type='button'
+				pressed={pressed}
+				onPressedChange={setPressed}
+				variant='outline'
+				aria-label='Later'
+				className='h-9 justify-start rounded-md px-3 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground'>
+				Later
+			</Toggle>
+		</div>
+	);
+}

--- a/src/components/task-detail-later-toggle.tsx
+++ b/src/components/task-detail-later-toggle.tsx
@@ -13,6 +13,10 @@ export function TaskDetailLaterToggle({
 }: TaskDetailLaterToggleProps) {
 	const [pressed, setPressed] = React.useState(defaultPressed);
 
+	React.useEffect(() => {
+		setPressed(defaultPressed);
+	}, [defaultPressed]);
+
 	return (
 		<div className='flex items-end'>
 			<input
@@ -26,7 +30,7 @@ export function TaskDetailLaterToggle({
 				onPressedChange={setPressed}
 				variant='outline'
 				aria-label='Later'
-				className='h-9 justify-start rounded-md px-3 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground'>
+				className='h-9 justify-start rounded-md px-3 cursor-pointer data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground'>
 				Later
 			</Toggle>
 		</div>


### PR DESCRIPTION
## Scope

Closes #74

- Replace the task detail `Later` checkbox with a Toggle-style control.
- Preserve the existing form submission contract by submitting hidden `detailLater=on` only when pressed.
- Update the affected done/reopen/later Playwright flow to assert toggle pressed state and disabled persistence.

## Validation

- `git diff --check` passed (Git reported CRLF normalization warnings only).
- `npm run lint` passed.
- `npm run build` passed.
- `npx playwright test e2e/task-complete-reopen.spec.ts --project=chromium --reporter=line` passed: 1/1.
- `npx playwright test --reporter=line` completed: 43 passed, 2 failed in Firefox/WebKit `e2e/create-task.spec.ts` on navigation interruption outside this issue; all Chromium tests passed.

## Notes

No unrelated dialog layout, status behavior, global token, typography, or other form-field changes.