### PR TITLE
Replace task detail links textarea

### DIFF
--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -33,16 +33,30 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await expect(page.getByRole('dialog', { name: 'Task detail' })).toBeVisible()
   await expect(page.getByLabel('Attached links')).toHaveCount(0)
 
-  await page
-    .locator('#detailLinks')
-    .fill(
-      [
-        'https://github.com/vercel/next.js',
-        'https://gitlab.com/gitlab-org/gitlab',
-        'https://localtaskhub.atlassian.net/browse/LTH-38',
-        'https://example.com/task-38',
-      ].join('\n'),
-    )
+  const linkInput = page.getByLabel('Link URL')
+  const addLinkButton = page.getByRole('button', { name: 'Add' })
+
+  await linkInput.fill(' https://github.com/vercel/next.js ')
+  await addLinkButton.click()
+  await linkInput.fill('https://gitlab.com/gitlab-org/gitlab')
+  await linkInput.press('Enter')
+  await linkInput.fill('https://localtaskhub.atlassian.net/browse/LTH-38')
+  await addLinkButton.click()
+  await linkInput.fill('https://example.com/task-38')
+  await addLinkButton.click()
+  await linkInput.fill('https://github.com/vercel/next.js')
+  await addLinkButton.click()
+
+  await expect(page.getByLabel('Attached links').getByRole('link')).toHaveCount(4)
+  await expect(page.locator('#detailLinks')).toHaveValue(
+    [
+      'https://github.com/vercel/next.js',
+      'https://gitlab.com/gitlab-org/gitlab',
+      'https://localtaskhub.atlassian.net/browse/LTH-38',
+      'https://example.com/task-38',
+    ].join('\n'),
+  )
+  await expect(linkInput).toHaveValue('')
 
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
@@ -62,6 +76,7 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await expect(attachedLinks).toBeVisible()
   await expect(githubLink).toHaveAttribute('href', 'https://github.com/vercel/next.js')
   await expect(githubLink).toHaveAttribute('target', '_blank')
+  await expect(githubLink).toHaveAttribute('rel', 'noreferrer noopener')
   await expect(gitlabLink).toHaveAttribute('href', 'https://gitlab.com/gitlab-org/gitlab')
   await expect(attachedLinks).toContainText('github.com')
   await expect(attachedLinks).toContainText('gitlab.com')

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -3,6 +3,7 @@ import { Download } from 'lucide-react';
 
 import type { TaskDetail } from '@/lib/server/tasks';
 import { TaskDetailLaterToggle } from '@/components/task-detail-later-toggle';
+import { TaskDetailLinksEditor } from '@/components/task-detail-links-editor';
 import { MarkdownEditor } from '@/components/markdown-editor';
 import { SelectFormField } from '@/components/select-form-field';
 import { Button } from '@/components/ui/button';
@@ -12,7 +13,6 @@ import {
 	DialogTitle
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { formatDuration } from '@/components/task-display-helpers';
 
 type UpdateTaskDetailAction = (
@@ -57,22 +57,6 @@ function getTimeSessionDurationLabel(startedAt: Date, endedAt: Date | null) {
 	);
 
 	return formatDuration(derivedSeconds);
-}
-
-function getLinkDomainHint(url: string) {
-	try {
-		return new URL(url).hostname.replace(/^www\./, '');
-	} catch {
-		return null;
-	}
-}
-
-function truncateLinkLabel(url: string, maxLength = 96) {
-	if (url.length <= maxLength) {
-		return url;
-	}
-
-	return `${url.slice(0, maxLength).trimEnd()}...`;
 }
 
 export function TaskDetailDialogContent({
@@ -152,47 +136,7 @@ export function TaskDetailDialogContent({
 						/>
 					</div>
 
-					<div>
-						<label
-							htmlFor='detailLinks'
-							className='text-sm font-medium'>
-							Links (one URL per line)
-						</label>
-						<Textarea
-							id='detailLinks'
-							name='detailLinks'
-							defaultValue={selectedTask.links.join('\n')}
-							className='min-h-24'
-						/>
-						{selectedTask.links.length > 0 ?
-							<ul
-								className='space-y-1 rounded-md border border-border bg-muted/20 p-2 text-sm'
-								aria-label='Attached links'>
-								{selectedTask.links.map((link) => {
-									const domainHint = getLinkDomainHint(link);
-
-									return (
-										<li
-											key={link}
-											className='flex items-center justify-between gap-3'>
-											<a
-												href={link}
-												target='_blank'
-												rel='noreferrer noopener'
-												className='truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
-												{truncateLinkLabel(link)}
-											</a>
-											{domainHint ?
-												<span className='shrink-0 text-xs text-muted-foreground'>
-													{domainHint}
-												</span>
-											:	null}
-										</li>
-									);
-								})}
-							</ul>
-						:	null}
-					</div>
+					<TaskDetailLinksEditor defaultLinks={selectedTask.links} />
 
 					<div>
 						<label

--- a/src/components/task-detail-links-editor.tsx
+++ b/src/components/task-detail-links-editor.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput
+} from '@/components/ui/input-group';
+
+type TaskDetailLinksEditorProps = {
+	defaultLinks: string[];
+};
+
+function getLinkDomainHint(url: string) {
+	try {
+		return new URL(url).hostname.replace(/^www\./, '');
+	} catch {
+		return null;
+	}
+}
+
+function truncateLinkLabel(url: string, maxLength = 96) {
+	if (url.length <= maxLength) {
+		return url;
+	}
+
+	return `${url.slice(0, maxLength).trimEnd()}...`;
+}
+
+export function TaskDetailLinksEditor({
+	defaultLinks
+}: TaskDetailLinksEditorProps) {
+	const [links, setLinks] = useState(defaultLinks);
+	const [pendingUrl, setPendingUrl] = useState('');
+
+	function addPendingUrl() {
+		const nextUrl = pendingUrl.trim();
+
+		if (!nextUrl) {
+			return;
+		}
+
+		setLinks((currentLinks) =>
+			currentLinks.includes(nextUrl) ? currentLinks : [...currentLinks, nextUrl]
+		);
+		setPendingUrl('');
+	}
+
+	return (
+		<div className='space-y-2'>
+			<label
+				htmlFor='detailLinkInput'
+				className='text-sm font-medium'>
+				Links
+			</label>
+			<InputGroup className='rounded-md border-border bg-input'>
+				<InputGroupInput
+					id='detailLinkInput'
+					type='url'
+					value={pendingUrl}
+					onChange={(event) => setPendingUrl(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key !== 'Enter') {
+							return;
+						}
+
+						event.preventDefault();
+						addPendingUrl();
+					}}
+					placeholder='Add URL'
+					aria-label='Link URL'
+				/>
+				<InputGroupAddon align='inline-end'>
+					<InputGroupButton
+						type='button'
+						variant='secondary'
+						onClick={addPendingUrl}>
+						Add
+					</InputGroupButton>
+				</InputGroupAddon>
+			</InputGroup>
+			<textarea
+				id='detailLinks'
+				name='detailLinks'
+				value={links.join('\n')}
+				readOnly
+				hidden
+			/>
+			{links.length > 0 ?
+				<ul
+					className='space-y-1 rounded-md border border-border bg-muted/20 p-2 text-sm'
+					aria-label='Attached links'>
+					{links.map((link) => {
+						const domainHint = getLinkDomainHint(link);
+
+						return (
+							<li
+								key={link}
+								className='flex items-center justify-between gap-3'>
+								<a
+									href={link}
+									target='_blank'
+									rel='noreferrer noopener'
+									className='truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
+									{truncateLinkLabel(link)}
+								</a>
+								{domainHint ?
+									<span className='shrink-0 text-xs text-muted-foreground'>
+										{domainHint}
+									</span>
+								:	null}
+							</li>
+						);
+					})}
+				</ul>
+			:	null}
+		</div>
+	);
+}

--- a/src/components/task-detail-links-editor.tsx
+++ b/src/components/task-detail-links-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
 	InputGroup,
@@ -34,6 +34,23 @@ export function TaskDetailLinksEditor({
 }: TaskDetailLinksEditorProps) {
 	const [links, setLinks] = useState(defaultLinks);
 	const [pendingUrl, setPendingUrl] = useState('');
+
+	useEffect(() => {
+		let isCurrent = true;
+
+		queueMicrotask(() => {
+			if (!isCurrent) {
+				return;
+			}
+
+			setLinks(defaultLinks);
+			setPendingUrl('');
+		});
+
+		return () => {
+			isCurrent = false;
+		};
+	}, [defaultLinks]);
 
 	function addPendingUrl() {
 		const nextUrl = pendingUrl.trim();


### PR DESCRIPTION
## Scope

Closes #78.

- Replace the task detail links textarea with a compact URL input group and Add button.
- Add a small client-side links editor that keeps the existing `detailLinks` newline-separated form contract via a hidden textarea.
- Update focused Playwright coverage for Add button, Enter-to-add, trimming, duplicate avoidance, clickable links, and persistence.

## Files changed

- `src/components/task-detail-dialog-content.tsx`
- `src/components/task-detail-links-editor.tsx`
- `e2e/task-detail-links.spec.ts`

## Validation

- `npm run lint` passed
- `npm run build` passed
- `npx playwright test e2e/task-detail-links.spec.ts --project=chromium --reporter=line` passed: 2 tests
- `git diff --check` passed

## Notes

- No packages added.
- No new input-group primitive added; the existing `src/components/ui/input-group.tsx` is reused unchanged.