### PR TITLE
Allow removing task detail links

### DIFF
--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -108,6 +108,67 @@ test('task detail renders attached links as clickable items and keeps one-per-li
   await expect(page.getByLabel('Attached links')).toBeVisible()
 })
 
+test('task detail removes attached links locally and persists the remaining links on save', async ({ page }) => {
+  const unique = Date.now().toString()
+  const title = `Issue80 Remove Links ${unique}`
+  const githubUrl = `https://github.com/daviddomain/local-task-hub/issues/${unique}`
+  const gitlabUrl = `https://gitlab.com/local-task-hub/remove-${unique}`
+  const docsUrl = `https://example.com/docs/${unique}`
+  const pendingUrl = `https://example.com/pending-${unique}`
+
+  await page.goto('/')
+  await showOnlyTask(page, title)
+
+  await page.getByRole('link', { name: 'Create task' }).click()
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toBeVisible()
+  await page.getByLabel('Title *').fill(title)
+  await page.getByLabel('First link (optional)').fill(githubUrl)
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.getByRole('button', { name: 'Create task' }).click(),
+  ])
+  await expect(page.getByRole('dialog', { name: 'Quick add' })).toHaveCount(0)
+
+  await showOnlyTask(page, title)
+  await openTaskDetail(page, title)
+
+  const linkInput = page.getByLabel('Link URL')
+  const addLinkButton = page.getByRole('button', { name: 'Add' })
+
+  await linkInput.fill(gitlabUrl)
+  await addLinkButton.click()
+  await linkInput.fill(docsUrl)
+  await addLinkButton.click()
+  await linkInput.fill(pendingUrl)
+
+  const attachedLinks = page.getByLabel('Attached links')
+  await expect(attachedLinks.getByRole('link')).toHaveCount(3)
+  await expect(page.locator('#detailLinks')).toHaveValue([githubUrl, gitlabUrl, docsUrl].join('\n'))
+
+  await page.getByRole('button', { name: `Remove link ${gitlabUrl}` }).click()
+
+  await expect(attachedLinks.getByRole('link', { name: gitlabUrl })).toHaveCount(0)
+  await expect(attachedLinks.getByRole('link')).toHaveCount(2)
+  await expect(page.locator('#detailLinks')).toHaveValue([githubUrl, docsUrl].join('\n'))
+  await expect(linkInput).toHaveValue(pendingUrl)
+
+  await Promise.all([
+    page.waitForResponse((response) => response.request().method() === 'POST'),
+    page.locator('#task-detail form').evaluate((form) => {
+      (form as HTMLFormElement).requestSubmit()
+    }),
+  ])
+
+  await showOnlyTask(page, title)
+  await openTaskDetail(page, title)
+
+  const reopenedLinks = page.getByLabel('Attached links')
+  await expect(reopenedLinks.getByRole('link', { name: githubUrl })).toBeVisible()
+  await expect(reopenedLinks.getByRole('link', { name: docsUrl })).toBeVisible()
+  await expect(reopenedLinks.getByRole('link', { name: gitlabUrl })).toHaveCount(0)
+  await expect(page.locator('#detailLinks')).toHaveValue([githubUrl, docsUrl].join('\n'))
+})
+
 test('task detail supports structured time session editing and explicit removal', async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue35 Sessions ${unique}`

--- a/src/components/task-detail-links-editor.tsx
+++ b/src/components/task-detail-links-editor.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { XIcon } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import {
 	InputGroup,
 	InputGroupAddon,
@@ -65,6 +67,10 @@ export function TaskDetailLinksEditor({
 		setPendingUrl('');
 	}
 
+	function removeLink(url: string) {
+		setLinks((currentLinks) => currentLinks.filter((link) => link !== url));
+	}
+
 	return (
 		<div className='space-y-2'>
 			<label
@@ -120,7 +126,7 @@ export function TaskDetailLinksEditor({
 									href={link}
 									target='_blank'
 									rel='noreferrer noopener'
-									className='truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
+									className='min-w-0 flex-1 truncate text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'>
 									{truncateLinkLabel(link)}
 								</a>
 								{domainHint ?
@@ -128,6 +134,15 @@ export function TaskDetailLinksEditor({
 										{domainHint}
 									</span>
 								:	null}
+								<Button
+									type='button'
+									variant='ghost'
+									size='icon-xs'
+									className='shrink-0 text-muted-foreground hover:text-foreground'
+									aria-label={`Remove link ${link}`}
+									onClick={() => removeLink(link)}>
+									<XIcon aria-hidden='true' />
+								</Button>
 							</li>
 						);
 					})}


### PR DESCRIPTION
## Scope
- Add a compact remove button to each task detail attached-link row.
- Keep the existing newline-serialized detailLinks hidden field in sync with local link removal.
- Add focused Playwright coverage for remove, hidden-field update, save, and reopen persistence.

Closes #80

## Validation
- git diff --check
- npm run lint
- npm run build
- npx playwright test e2e/task-detail-links.spec.ts --project=chromium --reporter=line