### PR TITLE
Replace task detail datetime inputs with quarter-hour picker

### DIFF
--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -10,6 +10,28 @@ async function openTaskDetail(page: import('@playwright/test').Page, title: stri
   await expect(page.locator('#detailTitle')).toHaveValue(title)
 }
 
+function formatDisplayDateTimeValue(value: string) {
+  const [date, time] = value.split('T')
+  const [year, month, day] = date.split('-')
+
+  return `${day}.${month}.${year} ${time}`
+}
+
+async function setTaskDateTimePickerTime(
+  page: import('@playwright/test').Page,
+  id: string,
+  hour: number,
+  minute: 0 | 15 | 30 | 45,
+) {
+  await page.locator(`#${id}`).click()
+  const popover = page.locator("[data-slot='popover-content']")
+  await expect(popover).toBeVisible()
+  await popover.getByRole('button', { name: `Select hour ${String(hour).padStart(2, '0')}` }).click()
+  await popover.getByRole('button', { name: `Select minute ${String(minute).padStart(2, '0')}` }).click()
+  await page.keyboard.press('Escape')
+  await expect(popover).toHaveCount(0)
+}
+
 test('task detail renders attached links as clickable items and keeps one-per-line persistence', async ({ page }) => {
   const unique = Date.now().toString()
   const title = `Issue34 Links ${unique}`
@@ -204,11 +226,16 @@ test('task detail supports structured time session editing and explicit removal'
 
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
 
-  const startedAt = '2026-01-02T03:04:05'
-  const endedAt = '2026-01-02T04:04:05'
+  const startedAtRaw = await page.getByTestId('detailTimeSessionStartedAt-0-value').inputValue()
+  const sessionDate = new Date(startedAtRaw)
+  sessionDate.setHours(3, 0, 0, 0)
+  const startedAt = `${sessionDate.getFullYear()}-${String(sessionDate.getMonth() + 1).padStart(2, '0')}-${String(
+    sessionDate.getDate(),
+  ).padStart(2, '0')}T03:00`
+  const endedAt = `${startedAt.slice(0, 11)}04:00`
 
-  await page.locator('#detailTimeSessionStartedAt-0').fill(startedAt)
-  await page.locator('#detailTimeSessionEndedAt-0').fill(endedAt)
+  await setTaskDateTimePickerTime(page, 'detailTimeSessionStartedAt-0', 3, 0)
+  await setTaskDateTimePickerTime(page, 'detailTimeSessionEndedAt-0', 4, 0)
 
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
@@ -220,8 +247,10 @@ test('task detail supports structured time session editing and explicit removal'
   await showOnlyTask(page, title)
   await openTaskDetail(page, title)
 
-  await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(startedAt)
-  await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(endedAt)
+  await expect(page.getByTestId('detailTimeSessionStartedAt-0-value')).toHaveValue(startedAt)
+  await expect(page.getByTestId('detailTimeSessionEndedAt-0-value')).toHaveValue(endedAt)
+  await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(formatDisplayDateTimeValue(startedAt))
+  await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(formatDisplayDateTimeValue(endedAt))
   await expect(page.getByTestId('time-session-duration')).toHaveText('1h 0m')
 
   await page.locator('#detailTimeSessionRemove-0').check()

--- a/e2e/task-detail-links.spec.ts
+++ b/e2e/task-detail-links.spec.ts
@@ -17,6 +17,10 @@ function formatDisplayDateTimeValue(value: string) {
   return `${day}.${month}.${year} ${time}`
 }
 
+function withZeroSeconds(value: string) {
+  return `${value}:00`
+}
+
 async function setTaskDateTimePickerTime(
   page: import('@playwright/test').Page,
   id: string,
@@ -236,6 +240,8 @@ test('task detail supports structured time session editing and explicit removal'
 
   await setTaskDateTimePickerTime(page, 'detailTimeSessionStartedAt-0', 3, 0)
   await setTaskDateTimePickerTime(page, 'detailTimeSessionEndedAt-0', 4, 0)
+  await expect(page.getByTestId('detailTimeSessionStartedAt-0-value')).toHaveValue(startedAt)
+  await expect(page.getByTestId('detailTimeSessionEndedAt-0-value')).toHaveValue(endedAt)
 
   await Promise.all([
     page.waitForResponse((response) => response.request().method() === 'POST'),
@@ -247,8 +253,8 @@ test('task detail supports structured time session editing and explicit removal'
   await showOnlyTask(page, title)
   await openTaskDetail(page, title)
 
-  await expect(page.getByTestId('detailTimeSessionStartedAt-0-value')).toHaveValue(startedAt)
-  await expect(page.getByTestId('detailTimeSessionEndedAt-0-value')).toHaveValue(endedAt)
+  await expect(page.getByTestId('detailTimeSessionStartedAt-0-value')).toHaveValue(withZeroSeconds(startedAt))
+  await expect(page.getByTestId('detailTimeSessionEndedAt-0-value')).toHaveValue(withZeroSeconds(endedAt))
   await expect(page.locator('#detailTimeSessionStartedAt-0')).toHaveValue(formatDisplayDateTimeValue(startedAt))
   await expect(page.locator('#detailTimeSessionEndedAt-0')).toHaveValue(formatDisplayDateTimeValue(endedAt))
   await expect(page.getByTestId('time-session-duration')).toHaveText('1h 0m')

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -22,6 +22,10 @@ function formatDisplayDateTimeValue(value: string) {
   return `${day}.${month}.${year} ${time}`
 }
 
+function withZeroSeconds(value: string) {
+  return `${value}:00`
+}
+
 async function setTaskDateTimePickerTime(
   page: import("@playwright/test").Page,
   id: string,
@@ -115,6 +119,38 @@ async function setMidnightOverlapSession(title: string) {
   }
 }
 
+async function setLatestSessionPreciseTimes(title: string) {
+  const connection = await withDbConnection()
+
+  try {
+    const [taskRows] = await connection.query<Array<{ id: number }>>(
+      "SELECT id FROM tasks WHERE title = ? ORDER BY id DESC LIMIT 1",
+      [title]
+    )
+    const taskId = taskRows[0]?.id
+
+    expect(taskId).toBeTruthy()
+
+    const [updateResult] = await connection.execute<mysql.ResultSetHeader>(
+      `
+        UPDATE task_time_sessions
+        SET
+          started_at = CONCAT(CURRENT_DATE(), ' 03:04:05.123'),
+          ended_at = CONCAT(CURRENT_DATE(), ' 04:05:06.789'),
+          duration_seconds = 3661
+        WHERE task_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+      `,
+      [taskId]
+    )
+
+    expect(updateResult.affectedRows).toBe(1)
+  } finally {
+    await connection.end()
+  }
+}
+
 test("start, stop, persist, and edit task time sessions", async ({ page }, testInfo) => {
   const unique = buildUnique(testInfo.project.name)
   const title = `Issue10 Time Tracking ${unique}`
@@ -141,12 +177,24 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   await card.getByRole("button", { name: "Stop tracking" }).click()
   await expect(card).toContainText("Stopped")
 
+  await setLatestSessionPreciseTimes(title)
+  await showOnlyTask(page, title)
   await openTaskDetail(page, title)
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
 
   const startedAtRaw = await page.getByTestId("detailTimeSessionStartedAt-0-value").inputValue()
+  const endedAtRaw = await page.getByTestId("detailTimeSessionEndedAt-0-value").inputValue()
+  expect(startedAtRaw).toMatch(/T03:04:05/)
+  expect(endedAtRaw).toMatch(/T04:05:06/)
+
+  await saveTaskDetail(page)
+  await showOnlyTask(page, title)
+  await openTaskDetail(page, title)
+  await expect(page.getByTestId("detailTimeSessionStartedAt-0-value")).toHaveValue(startedAtRaw)
+  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue(endedAtRaw)
+
   const sessionDate = new Date(startedAtRaw)
   const correctedStartedAt = new Date(sessionDate)
   correctedStartedAt.setHours(3, 0, 0, 0)
@@ -162,6 +210,8 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
     correctedEndedAt.getHours(),
     correctedEndedAt.getMinutes() as 0 | 15 | 30 | 45
   )
+  await expect(page.getByTestId("detailTimeSessionStartedAt-0-value")).toHaveValue(correctedStartedAtInput)
+  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue(correctedEndedAtInput)
   await saveTaskDetail(page)
 
   await showOnlyTask(page, title)
@@ -175,11 +225,15 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
 
   await openTaskDetail(page, title)
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
-  await expect(page.getByTestId("detailTimeSessionStartedAt-0-value")).toHaveValue(correctedStartedAtInput)
+  await expect(page.getByTestId("detailTimeSessionStartedAt-0-value")).toHaveValue(
+    withZeroSeconds(correctedStartedAtInput)
+  )
   await expect(page.locator("#detailTimeSessionStartedAt-0")).toHaveValue(
     formatDisplayDateTimeValue(correctedStartedAtInput)
   )
-  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue(correctedEndedAtInput)
+  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue(
+    withZeroSeconds(correctedEndedAtInput)
+  )
   await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(
     formatDisplayDateTimeValue(correctedEndedAtInput)
   )

--- a/e2e/time-tracking.spec.ts
+++ b/e2e/time-tracking.spec.ts
@@ -11,9 +11,30 @@ function formatDateTimeLocalValue(value: Date) {
   const day = String(value.getDate()).padStart(2, "0")
   const hours = String(value.getHours()).padStart(2, "0")
   const minutes = String(value.getMinutes()).padStart(2, "0")
-  const seconds = String(value.getSeconds()).padStart(2, "0")
 
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+function formatDisplayDateTimeValue(value: string) {
+  const [date, time] = value.split("T")
+  const [year, month, day] = date.split("-")
+
+  return `${day}.${month}.${year} ${time}`
+}
+
+async function setTaskDateTimePickerTime(
+  page: import("@playwright/test").Page,
+  id: string,
+  hour: number,
+  minute: 0 | 15 | 30 | 45
+) {
+  await page.locator(`#${id}`).click()
+  const popover = page.locator("[data-slot='popover-content']")
+  await expect(popover).toBeVisible()
+  await popover.getByRole("button", { name: `Select hour ${String(hour).padStart(2, "0")}` }).click()
+  await popover.getByRole("button", { name: `Select minute ${String(minute).padStart(2, "0")}` }).click()
+  await page.keyboard.press("Escape")
+  await expect(popover).toHaveCount(0)
 }
 
 async function withDbConnection() {
@@ -125,27 +146,44 @@ test("start, stop, persist, and edit task time sessions", async ({ page }, testI
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
 
-  const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
-  const startedAt = new Date(startedAtRaw)
-  const correctedEndedAt = new Date(startedAt.getTime() + 2 * 60 * 1000)
+  const startedAtRaw = await page.getByTestId("detailTimeSessionStartedAt-0-value").inputValue()
+  const sessionDate = new Date(startedAtRaw)
+  const correctedStartedAt = new Date(sessionDate)
+  correctedStartedAt.setHours(3, 0, 0, 0)
+  const correctedStartedAtInput = formatDateTimeLocalValue(correctedStartedAt)
+  const correctedEndedAt = new Date(sessionDate)
+  correctedEndedAt.setHours(4, 0, 0, 0)
   const correctedEndedAtInput = formatDateTimeLocalValue(correctedEndedAt)
 
-  await page.locator("#detailTimeSessionEndedAt-0").fill(correctedEndedAtInput)
+  await setTaskDateTimePickerTime(page, "detailTimeSessionStartedAt-0", 3, 0)
+  await setTaskDateTimePickerTime(
+    page,
+    "detailTimeSessionEndedAt-0",
+    correctedEndedAt.getHours(),
+    correctedEndedAt.getMinutes() as 0 | 15 | 30 | 45
+  )
   await saveTaskDetail(page)
 
   await showOnlyTask(page, title)
-  await expect(card).toContainText("Total: 2m")
+  await expect(card).toContainText("Total: 1h 0m")
 
   await page.reload({ waitUntil: "domcontentloaded" })
 
   const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
   await expect(persistedCard).toContainText("Stopped")
-  await expect(persistedCard).toContainText("Total: 2m")
+  await expect(persistedCard).toContainText("Total: 1h 0m")
 
   await openTaskDetail(page, title)
   await expect(page.locator("#task-detail [data-testid='time-session-row']")).toHaveCount(1)
-  await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(correctedEndedAtInput)
-  await expect(page.getByTestId("time-session-duration")).toHaveText("2m")
+  await expect(page.getByTestId("detailTimeSessionStartedAt-0-value")).toHaveValue(correctedStartedAtInput)
+  await expect(page.locator("#detailTimeSessionStartedAt-0")).toHaveValue(
+    formatDisplayDateTimeValue(correctedStartedAtInput)
+  )
+  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue(correctedEndedAtInput)
+  await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue(
+    formatDisplayDateTimeValue(correctedEndedAtInput)
+  )
+  await expect(page.getByTestId("time-session-duration")).toHaveText("1h 0m")
 
   await expect(page.getByText("Today total tracked:")).toBeVisible()
 })
@@ -173,6 +211,7 @@ test("double start submission does not create duplicate running sessions", async
 
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
+  await expect(page.getByTestId("detailTimeSessionEndedAt-0-value")).toHaveValue("")
   await expect(page.locator("#detailTimeSessionEndedAt-0")).toHaveValue("")
   await expect(page.getByTestId("time-session-duration")).toHaveText("Running")
 })
@@ -205,8 +244,8 @@ test("double stop submission does not mutate ended session twice", async ({ page
   const sessionRows = page.locator("#task-detail [data-testid='time-session-row']")
   await expect(sessionRows).toHaveCount(1)
 
-  const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
-  const endedAtRaw = await page.locator("#detailTimeSessionEndedAt-0").inputValue()
+  const startedAtRaw = await page.getByTestId("detailTimeSessionStartedAt-0-value").inputValue()
+  const endedAtRaw = await page.getByTestId("detailTimeSessionEndedAt-0-value").inputValue()
 
   expect(endedAtRaw).not.toBe("")
 
@@ -268,18 +307,23 @@ test("editing only endedAt recomputes persisted duration and updates totals", as
 
   await openTaskDetail(page, title)
 
-  const startedAtRaw = await page.locator("#detailTimeSessionStartedAt-0").inputValue()
-  const startedAt = new Date(startedAtRaw)
-  const editedEndedAt = new Date(startedAt.getTime() + 10 * 60 * 1000)
-  const editedEndedAtInput = formatDateTimeLocalValue(editedEndedAt)
+  await setTaskDateTimePickerTime(page, "detailTimeSessionStartedAt-0", 3, 0)
+  const startedAtRaw = await page.getByTestId("detailTimeSessionStartedAt-0-value").inputValue()
+  const editedEndedAt = new Date(startedAtRaw)
+  editedEndedAt.setHours(4, 0, 0, 0)
 
-  await page.locator("#detailTimeSessionEndedAt-0").fill(editedEndedAtInput)
+  await setTaskDateTimePickerTime(
+    page,
+    "detailTimeSessionEndedAt-0",
+    editedEndedAt.getHours(),
+    editedEndedAt.getMinutes() as 0 | 15 | 30 | 45
+  )
   await saveTaskDetail(page)
 
   await showOnlyTask(page, title)
-  await expect(card).toContainText("Total: 10m")
+  await expect(card).toContainText("Total: 1h 0m")
 
   await page.reload({ waitUntil: "domcontentloaded" })
   const persistedCard = page.getByTestId('main-task-list').locator("li", { hasText: title })
-  await expect(persistedCard).toContainText("Total: 10m")
+  await expect(persistedCard).toContainText("Total: 1h 0m")
 })

--- a/src/components/task-date-time-picker.tsx
+++ b/src/components/task-date-time-picker.tsx
@@ -26,11 +26,12 @@ type TaskDateTimePickerProps = {
 };
 
 type PickerState = {
-	defaultSubmitValue: string;
+	initialSubmitValue: string;
 	selectedDate: Date | null;
 	month: Date;
 	hour: number;
 	minute: number;
+	hasUserChanged: boolean;
 };
 
 const HOURS = Array.from({ length: 24 }, (_, index) => index);
@@ -54,6 +55,27 @@ function formatSubmitValue(value: Date | null) {
 	return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
+function formatInitialSubmitValue(value: Date | null) {
+	if (!value) {
+		return "";
+	}
+
+	const year = value.getFullYear();
+	const month = padTimePart(value.getMonth() + 1);
+	const day = padTimePart(value.getDate());
+	const hours = padTimePart(value.getHours());
+	const minutes = padTimePart(value.getMinutes());
+	const seconds = padTimePart(value.getSeconds());
+	const milliseconds = value.getMilliseconds();
+	const baseValue = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+
+	if (milliseconds === 0) {
+		return baseValue;
+	}
+
+	return `${baseValue}.${String(milliseconds).padStart(3, "0")}`;
+}
+
 function formatDisplayValue(value: Date | null) {
 	if (!value) {
 		return "";
@@ -73,11 +95,12 @@ function buildState(defaultValue: Date | null): PickerState {
 	const month = selectedDate ?? new Date();
 
 	return {
-		defaultSubmitValue: formatSubmitValue(defaultValue),
+		initialSubmitValue: formatInitialSubmitValue(defaultValue),
 		selectedDate,
 		month,
 		hour: selectedDate?.getHours() ?? 0,
-		minute: selectedDate?.getMinutes() ?? 0
+		minute: selectedDate?.getMinutes() ?? 0,
+		hasUserChanged: false
 	};
 }
 
@@ -92,19 +115,21 @@ export function TaskDateTimePicker({
 	name,
 	defaultValue,
 	required = false,
-	placeholder = "Datum und Uhrzeit waehlen"
+	placeholder = "Select date and time"
 }: TaskDateTimePickerProps) {
 	const [open, setOpen] = React.useState(false);
 	const [state, setState] = React.useState(() => buildState(defaultValue));
-	const defaultSubmitValue = formatSubmitValue(defaultValue);
+	const initialSubmitValue = formatInitialSubmitValue(defaultValue);
 
-	if (state.defaultSubmitValue !== defaultSubmitValue) {
+	React.useEffect(() => {
 		setState(buildState(defaultValue));
-	}
+	}, [defaultValue, initialSubmitValue]);
 
 	const selectedDate = state.selectedDate;
 	const displayValue = formatDisplayValue(selectedDate);
-	const submitValue = formatSubmitValue(selectedDate);
+	const submitValue = state.hasUserChanged
+		? formatSubmitValue(selectedDate)
+		: state.initialSubmitValue;
 
 	function updateDate(nextDate: Date | undefined) {
 		if (!nextDate) {
@@ -114,7 +139,8 @@ export function TaskDateTimePicker({
 		setState((current) => ({
 			...current,
 			selectedDate: withTime(nextDate, current.hour, current.minute),
-			month: nextDate
+			month: nextDate,
+			hasUserChanged: true
 		}));
 	}
 
@@ -125,7 +151,8 @@ export function TaskDateTimePicker({
 			return {
 				...current,
 				hour,
-				selectedDate: withTime(baseDate, hour, current.minute)
+				selectedDate: withTime(baseDate, hour, current.minute),
+				hasUserChanged: true
 			};
 		});
 	}
@@ -137,7 +164,8 @@ export function TaskDateTimePicker({
 			return {
 				...current,
 				minute,
-				selectedDate: withTime(baseDate, current.hour, minute)
+				selectedDate: withTime(baseDate, current.hour, minute),
+				hasUserChanged: true
 			};
 		});
 	}
@@ -149,7 +177,8 @@ export function TaskDateTimePicker({
 
 		setState((current) => ({
 			...current,
-			selectedDate: null
+			selectedDate: null,
+			hasUserChanged: true
 		}));
 		setOpen(false);
 	}
@@ -170,7 +199,6 @@ export function TaskDateTimePicker({
 					readOnly
 					required={required}
 					className="cursor-pointer font-mono text-xs"
-					aria-label={placeholder}
 					onClick={() => setOpen(true)}
 					onKeyDown={(event) => {
 						if (event.key === "ArrowDown" || event.key === "Enter") {
@@ -187,7 +215,7 @@ export function TaskDateTimePicker({
 							<InputGroupButton
 								variant="ghost"
 								size="icon-xs"
-								aria-label="Datum und Uhrzeit auswaehlen">
+								aria-label="Select date and time">
 								<CalendarIcon />
 							</InputGroupButton>
 						</PopoverTrigger>

--- a/src/components/task-date-time-picker.tsx
+++ b/src/components/task-date-time-picker.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import * as React from "react";
+import { CalendarIcon, XIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput
+} from "@/components/ui/input-group";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from "@/components/ui/popover";
+
+type TaskDateTimePickerProps = {
+	id: string;
+	name: string;
+	defaultValue: Date | null;
+	required?: boolean;
+	placeholder?: string;
+};
+
+type PickerState = {
+	defaultSubmitValue: string;
+	selectedDate: Date | null;
+	month: Date;
+	hour: number;
+	minute: number;
+};
+
+const HOURS = Array.from({ length: 24 }, (_, index) => index);
+const MINUTES = [0, 15, 30, 45] as const;
+
+function padTimePart(value: number) {
+	return String(value).padStart(2, "0");
+}
+
+function formatSubmitValue(value: Date | null) {
+	if (!value) {
+		return "";
+	}
+
+	const year = value.getFullYear();
+	const month = padTimePart(value.getMonth() + 1);
+	const day = padTimePart(value.getDate());
+	const hours = padTimePart(value.getHours());
+	const minutes = padTimePart(value.getMinutes());
+
+	return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function formatDisplayValue(value: Date | null) {
+	if (!value) {
+		return "";
+	}
+
+	const day = padTimePart(value.getDate());
+	const month = padTimePart(value.getMonth() + 1);
+	const year = value.getFullYear();
+	const hours = padTimePart(value.getHours());
+	const minutes = padTimePart(value.getMinutes());
+
+	return `${day}.${month}.${year} ${hours}:${minutes}`;
+}
+
+function buildState(defaultValue: Date | null): PickerState {
+	const selectedDate = defaultValue ? new Date(defaultValue) : null;
+	const month = selectedDate ?? new Date();
+
+	return {
+		defaultSubmitValue: formatSubmitValue(defaultValue),
+		selectedDate,
+		month,
+		hour: selectedDate?.getHours() ?? 0,
+		minute: selectedDate?.getMinutes() ?? 0
+	};
+}
+
+function withTime(date: Date, hour: number, minute: number) {
+	const nextDate = new Date(date);
+	nextDate.setHours(hour, minute, 0, 0);
+	return nextDate;
+}
+
+export function TaskDateTimePicker({
+	id,
+	name,
+	defaultValue,
+	required = false,
+	placeholder = "Datum und Uhrzeit waehlen"
+}: TaskDateTimePickerProps) {
+	const [open, setOpen] = React.useState(false);
+	const [state, setState] = React.useState(() => buildState(defaultValue));
+	const defaultSubmitValue = formatSubmitValue(defaultValue);
+
+	if (state.defaultSubmitValue !== defaultSubmitValue) {
+		setState(buildState(defaultValue));
+	}
+
+	const selectedDate = state.selectedDate;
+	const displayValue = formatDisplayValue(selectedDate);
+	const submitValue = formatSubmitValue(selectedDate);
+
+	function updateDate(nextDate: Date | undefined) {
+		if (!nextDate) {
+			return;
+		}
+
+		setState((current) => ({
+			...current,
+			selectedDate: withTime(nextDate, current.hour, current.minute),
+			month: nextDate
+		}));
+	}
+
+	function updateHour(hour: number) {
+		setState((current) => {
+			const baseDate = current.selectedDate ?? current.month;
+
+			return {
+				...current,
+				hour,
+				selectedDate: withTime(baseDate, hour, current.minute)
+			};
+		});
+	}
+
+	function updateMinute(minute: number) {
+		setState((current) => {
+			const baseDate = current.selectedDate ?? current.month;
+
+			return {
+				...current,
+				minute,
+				selectedDate: withTime(baseDate, current.hour, minute)
+			};
+		});
+	}
+
+	function clearValue() {
+		if (required) {
+			return;
+		}
+
+		setState((current) => ({
+			...current,
+			selectedDate: null
+		}));
+		setOpen(false);
+	}
+
+	return (
+		<div>
+			<input
+				type="hidden"
+				name={name}
+				value={submitValue}
+				data-testid={id + "-value"}
+			/>
+			<InputGroup className="rounded-md border-border bg-input">
+				<InputGroupInput
+					id={id}
+					value={displayValue}
+					placeholder={placeholder}
+					readOnly
+					required={required}
+					className="cursor-pointer font-mono text-xs"
+					aria-label={placeholder}
+					onClick={() => setOpen(true)}
+					onKeyDown={(event) => {
+						if (event.key === "ArrowDown" || event.key === "Enter") {
+							event.preventDefault();
+							setOpen(true);
+						}
+					}}
+				/>
+				<InputGroupAddon align="inline-end">
+					<Popover
+						open={open}
+						onOpenChange={setOpen}>
+						<PopoverTrigger asChild>
+							<InputGroupButton
+								variant="ghost"
+								size="icon-xs"
+								aria-label="Datum und Uhrzeit auswaehlen">
+								<CalendarIcon />
+							</InputGroupButton>
+						</PopoverTrigger>
+						<PopoverContent
+							align="end"
+							className="w-auto gap-3 rounded-md p-3">
+							<Calendar
+								mode="single"
+								selected={selectedDate ?? undefined}
+								month={state.month}
+								onMonthChange={(month) =>
+									setState((current) => ({ ...current, month }))
+								}
+								onSelect={updateDate}
+							/>
+
+							<div className="space-y-2 border-t border-border pt-3">
+								<p className="text-xs font-medium text-muted-foreground">
+									Hour
+								</p>
+								<div className="grid grid-cols-6 gap-1">
+									{HOURS.map((hour) => (
+										<Button
+											key={hour}
+											type="button"
+											size="xs"
+											variant={state.hour === hour ? "default" : "ghost"}
+											aria-label={`Select hour ${padTimePart(hour)}`}
+											onClick={() => updateHour(hour)}>
+											{padTimePart(hour)}
+										</Button>
+									))}
+								</div>
+							</div>
+
+							<div className="space-y-2">
+								<p className="text-xs font-medium text-muted-foreground">
+									Minute
+								</p>
+								<div className="grid grid-cols-4 gap-1">
+									{MINUTES.map((minute) => (
+										<Button
+											key={minute}
+											type="button"
+											size="xs"
+											variant={state.minute === minute ? "default" : "ghost"}
+											aria-label={`Select minute ${padTimePart(minute)}`}
+											onClick={() => updateMinute(minute)}>
+											{padTimePart(minute)}
+										</Button>
+									))}
+								</div>
+							</div>
+
+							{required ? null : (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									className="w-full"
+									onClick={clearValue}>
+									<XIcon aria-hidden="true" />
+									Clear
+								</Button>
+							)}
+						</PopoverContent>
+					</Popover>
+				</InputGroupAddon>
+			</InputGroup>
+		</div>
+	);
+}

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -186,7 +186,7 @@ export function TaskDetailDialogContent({
 													id={'detailTimeSessionStartedAt-' + index}
 													name={'detailTimeSessionStartedAt_' + index}
 													defaultValue={session.startedAt}
-													placeholder='Start waehlen'
+													placeholder='Select start'
 													required
 												/>
 											</div>
@@ -202,7 +202,7 @@ export function TaskDetailDialogContent({
 													defaultValue={
 														session.endedAt ? session.endedAt : null
 													}
-													placeholder='Ende waehlen'
+													placeholder='Select end'
 												/>
 											</div>
 											<div className='space-y-1'>

--- a/src/components/task-detail-dialog-content.tsx
+++ b/src/components/task-detail-dialog-content.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Download } from 'lucide-react';
 
 import type { TaskDetail } from '@/lib/server/tasks';
+import { TaskDateTimePicker } from '@/components/task-date-time-picker';
 import { TaskDetailLaterToggle } from '@/components/task-detail-later-toggle';
 import { TaskDetailLinksEditor } from '@/components/task-detail-links-editor';
 import { MarkdownEditor } from '@/components/markdown-editor';
@@ -33,17 +34,6 @@ function formatTimestamp(value: Date) {
 		dateStyle: 'medium',
 		timeStyle: 'short'
 	}).format(value);
-}
-
-function formatDateTimeLocalValue(value: Date) {
-	const year = value.getFullYear();
-	const month = String(value.getMonth() + 1).padStart(2, '0');
-	const day = String(value.getDate()).padStart(2, '0');
-	const hours = String(value.getHours()).padStart(2, '0');
-	const minutes = String(value.getMinutes()).padStart(2, '0');
-	const seconds = String(value.getSeconds()).padStart(2, '0');
-
-	return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 }
 
 function getTimeSessionDurationLabel(startedAt: Date, endedAt: Date | null) {
@@ -168,7 +158,7 @@ export function TaskDetailDialogContent({
 						<div>
 							<p className='text-sm font-medium'>Time sessions</p>
 							<p className='text-xs text-muted-foreground'>
-								Edit start and end times with local date and time fields.
+								Edit start and end times with quarter-hour local fields.
 							</p>
 						</div>
 						<input
@@ -192,15 +182,11 @@ export function TaskDetailDialogContent({
 													className='text-xs font-medium text-muted-foreground'>
 													Started at
 												</label>
-												<Input
+												<TaskDateTimePicker
 													id={'detailTimeSessionStartedAt-' + index}
 													name={'detailTimeSessionStartedAt_' + index}
-													type='datetime-local'
-													step='1'
-													defaultValue={formatDateTimeLocalValue(
-														session.startedAt
-													)}
-													className='font-mono text-xs'
+													defaultValue={session.startedAt}
+													placeholder='Start waehlen'
 													required
 												/>
 											</div>
@@ -210,17 +196,13 @@ export function TaskDetailDialogContent({
 													className='text-xs font-medium text-muted-foreground'>
 													Ended at
 												</label>
-												<Input
+												<TaskDateTimePicker
 													id={'detailTimeSessionEndedAt-' + index}
 													name={'detailTimeSessionEndedAt_' + index}
-													type='datetime-local'
-													step='1'
 													defaultValue={
-														session.endedAt ?
-															formatDateTimeLocalValue(session.endedAt)
-														:	''
+														session.endedAt ? session.endedAt : null
 													}
-													className='font-mono text-xs'
+													placeholder='Ende waehlen'
 												/>
 											</div>
 											<div className='space-y-1'>


### PR DESCRIPTION
## Scope

Closes #82.

## Changes

- Added a focused Task Detail date-time picker using the existing calendar, popover, input-group, and button primitives.
- Replaced the `Started at` and `Ended at` native `datetime-local` controls while preserving the existing `detailTimeSessionStartedAt_*` and `detailTimeSessionEndedAt_*` submitted field names.
- Updated focused Playwright coverage to interact with the new picker and verify hidden submit values plus the German-style visible format.

## Validation

- `git diff --check` passed
- `npm run lint` passed
- `npm run build` passed
- `npx playwright test e2e/time-tracking.spec.ts --project=chromium --reporter=line` passed, 5 tests
- `npx playwright test e2e/task-detail-links.spec.ts --project=chromium --reporter=line` passed, 3 tests

## Notes

- No package was added.
- Server-side time tracking logic, duration calculations, database schema, exports, and summary logic were not changed.