### PR TITLE
Move task filters above task list

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -435,14 +435,6 @@ export default async function Home({
 								todayWorkedSummary={todayWorkedSummary}
 								visibleLimit={TODAY_WORKED_SUMMARY_VISIBLE_LIMIT}
 							/>
-
-							<TaskFilters
-								activeFilterLabels={activeFilterLabels}
-								filters={filters}
-								peopleOptions={peopleOptions}
-								statusOptions={STATUS_OPTIONS}
-								tagOptions={tagOptions}
-							/>
 						</CardContent>
 					</Card>
 
@@ -456,6 +448,15 @@ export default async function Home({
 					className='lg:sticky lg:top-8 lg:self-start'
 					aria-label='Task list'>
 					<TaskList
+						filtersContent={
+							<TaskFilters
+								activeFilterLabels={activeFilterLabels}
+								filters={filters}
+								peopleOptions={peopleOptions}
+								statusOptions={STATUS_OPTIONS}
+								tagOptions={tagOptions}
+							/>
+						}
 						openQuickAddHref={openQuickAddHref}
 						selectedTaskId={selectedTask?.id ?? null}
 						startTrackingAction={startTrackingAction}

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { Play, Plus, Search, Square } from 'lucide-react';
 
 import type { Task } from '@/lib/server/tasks';
@@ -29,6 +30,7 @@ import {
 type TaskTrackingAction = (formData: FormData) => Promise<void>;
 
 type TaskListProps = {
+	filtersContent?: ReactNode;
 	openQuickAddHref: string;
 	selectedTaskId: number | null;
 	startTrackingAction: TaskTrackingAction;
@@ -38,6 +40,7 @@ type TaskListProps = {
 };
 
 export function TaskList({
+	filtersContent,
 	openQuickAddHref,
 	selectedTaskId,
 	startTrackingAction,
@@ -55,6 +58,12 @@ export function TaskList({
 				</CardDescription>
 			</CardHeader>
 			<CardContent className='min-h-0 flex-1 overflow-y-auto'>
+				{filtersContent ?
+					<div className='mb-5 border-b border-border pb-5'>
+						{filtersContent}
+					</div>
+				:	null}
+
 				{tasks.length === 0 ?
 					<Empty className='border border-dashed border-border bg-muted/20'>
 						<EmptyHeader>


### PR DESCRIPTION
## Scope

Closes #86.

## Changes

- Move the existing `TaskFilters` form out of the left workspace card.
- Render the existing filter form inside the task-list card, between the result summary and task cards.
- Add a narrow task-list content slot so filter/search/URL behavior stays owned by the existing page state.

## Validation

- `git diff --check` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npx playwright test ./e2e/search-filtering.spec.ts --project=chromium --reporter=line` passed.
- Local browser layout check passed: filters are in the task-list section, after the summary and before results.